### PR TITLE
Fix stats endpoint imports

### DIFF
--- a/pages/api/debates/stats.js
+++ b/pages/api/debates/stats.js
@@ -1,6 +1,6 @@
 // pages/api/debates/stats.js
-import dbConnect from '/lib/dbConnect';
-import Deliberate from '/models/Deliberate';
+import dbConnect from '../../../lib/dbConnect';
+import Deliberate from '../../../models/Deliberate';
 
 export default async function handler(req, res) {
     await dbConnect();
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
             // Sort by closest split (difference ratio near 0)
             debates.sort((a, b) => {
                 const totalA = a.votesRed + a.votesBlue;
-                const totalB = b.votesBlue + b.votesBlue;
+                const totalB = b.votesRed + b.votesBlue;
                 const ratioA = Math.abs(a.votesRed - a.votesBlue) / totalA;
                 const ratioB = Math.abs(b.votesRed - b.votesBlue) / totalB;
                 return ratioA - ratioB; // smaller ratio => more divisive

--- a/pages/api/stats.js
+++ b/pages/api/stats.js
@@ -1,6 +1,6 @@
 // pages/api/debates/stats.js
-import dbConnect from '/lib/dbConnect';
-import Debate from '/models/Debate';
+import dbConnect from '../../lib/dbConnect';
+import Debate from '../../models/Debate';
 
 export default async function handler(req, res) {
     await dbConnect();


### PR DESCRIPTION
## Summary
- fix import paths in stats API files
- correct calculation of totalB when sorting deliberations

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d946d47a8832d8dd83bb39da5fe21