### PR TITLE
Fix deliberate page fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -43,7 +43,7 @@ export default function DeliberatePage({ initialDebates }) {
 
     const fetchDeliberations = async () => {
         try {
-            const response = await fetch('https://bicker-rosy.vercel.app/deliberate');
+            const response = await fetch('/api/deliberate');
             const data = await response.json();
             if (!response.ok) {
                 throw new Error(data.error || 'Failed to fetch deliberations');
@@ -294,8 +294,11 @@ export default function DeliberatePage({ initialDebates }) {
 }
 
 // Server-side props with randomized debates
-export async function getServerSideProps() {
-    const res = await fetch('https://bicker-rosy.vercel.app/deliberate');
+export async function getServerSideProps(context) {
+    const protocol = context.req.headers["x-forwarded-proto"] || "http";
+    const host = context.req.headers["host"];
+    const baseUrl = `${protocol}://${host}`;
+    const res = await fetch(`${baseUrl}/api/deliberate`);
     let initialDebates = [];
     try {
         initialDebates = await res.json();


### PR DESCRIPTION
## Summary
- fetch deliberations from internal API route
- compute base url in getServerSideProps
- ignore node_modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686830af7f38832d96679d1c9c6aea32