### PR TITLE
Improve SEO with sitemap and detail pages

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,6 +1,13 @@
 export default {
   title: 'Bicker',
-  description: 'the game of instigating, debating, and deliberating!',
+  description: 'The game of instigating, debating, and deliberating!',
+  additionalMetaTags: [
+    {
+      name: 'keywords',
+      content:
+        'bicker, debate, deliberate, instigate, online debate game',
+    },
+  ],
   openGraph: {
     type: 'website',
     locale: 'en_US',
@@ -8,4 +15,4 @@ export default {
     site_name: 'Bicker',
   },
 
-}; 
+};

--- a/pages/Leaderboard/global.js
+++ b/pages/Leaderboard/global.js
@@ -1,6 +1,7 @@
 // pages/leaderboard/global.js
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import NavBar from '../../components/NavBar';
 
 export default function GlobalStats() {
@@ -174,8 +175,8 @@ export default function GlobalStats() {
                                 const bluePercent = 100 - redPercent;
 
                                 return (
+                                    <Link key={debate._id} href={`/debates/${debate._id}`} passHref>
                                     <div
-                                        key={debate._id}
                                         style={{
                                             backgroundColor: 'white',
                                             borderRadius: '15px',
@@ -256,6 +257,7 @@ export default function GlobalStats() {
                                             </div>
                                         </div>
                                     </div>
+                                    </Link>
                                 );
                             })}
                         </div>

--- a/pages/api/debate/[id].js
+++ b/pages/api/debate/[id].js
@@ -1,0 +1,23 @@
+import dbConnect from '../../../lib/dbConnect';
+import Debate from '../../../models/Debate';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  const { id } = req.query;
+
+  if (req.method === 'GET') {
+    try {
+      const debate = await Debate.findById(id);
+      if (!debate) {
+        return res.status(404).json({ error: 'Debate not found' });
+      }
+      return res.status(200).json(debate);
+    } catch (error) {
+      console.error('Error fetching debate:', error);
+      return res.status(500).json({ error: 'Failed to fetch debate' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/deliberate/[id].js
+++ b/pages/api/deliberate/[id].js
@@ -1,0 +1,23 @@
+import dbConnect from '../../../lib/dbConnect';
+import Deliberate from '../../../models/Deliberate';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  const { id } = req.query;
+
+  if (req.method === 'GET') {
+    try {
+      const deliberation = await Deliberate.findById(id);
+      if (!deliberation) {
+        return res.status(404).json({ error: 'Deliberation not found' });
+      }
+      return res.status(200).json(deliberation);
+    } catch (error) {
+      console.error('Error fetching deliberation:', error);
+      return res.status(500).json({ error: 'Failed to fetch deliberation' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/debate.js
+++ b/pages/debate.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import NavBar from '../components/NavBar';
 import { useSession } from 'next-auth/react';
+import { NextSeo } from 'next-seo';
 
 export default function DebatePage({ initialDebates }) {
     const [instigates, setInstigates] = useState(initialDebates || []);
@@ -237,6 +238,9 @@ export default function DebatePage({ initialDebates }) {
             }}
         >
             <NavBar />
+            <NextSeo
+                title="Debate - Bicker"
+                description="Join ongoing debates and share your stance."/>
 
             {/* Mobile Search Bar */}
             {isMobile && (

--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -1,0 +1,42 @@
+import { NextSeo } from 'next-seo';
+import NavBar from '../../components/NavBar';
+
+export default function DebateDetail({ debate }) {
+  if (!debate) {
+    return <div>Debate not found</div>;
+  }
+
+  return (
+    <div style={{ paddingTop: '70px', fontFamily: 'Arial, sans-serif' }}>
+      <NextSeo
+        title={`Debate: ${debate.instigateText}`}
+        description={debate.debateText}
+        canonical={`https://www.yoursite.com/debates/${debate._id}`}
+        openGraph={{
+          url: `https://www.yoursite.com/debates/${debate._id}`,
+          title: `Debate: ${debate.instigateText}`,
+          description: debate.debateText,
+        }}
+      />
+      <NavBar />
+      <h1 style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
+      <p style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ params, req }) {
+  const protocol = req.headers["x-forwarded-proto"] || "http";
+  const baseUrl = `${protocol}://${req.headers.host}`;
+  try {
+    const res = await fetch(`${baseUrl}/api/debate/${params.id}`);
+    if (!res.ok) {
+      return { notFound: true };
+    }
+    const debate = await res.json();
+    return { props: { debate } };
+  } catch (error) {
+    console.error('Failed to load debate:', error);
+    return { props: { debate: null } };
+  }
+}

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { getServerSession } from 'next-auth';
 import { authOptions } from './api/auth/[...nextauth]';
 import NavBar from '../components/NavBar'; // If you have a NavBar; otherwise remove
+import { NextSeo } from 'next-seo';
 
 // Helper function to shuffle array
 const shuffleArray = (array) => {
@@ -199,6 +200,9 @@ export default function DeliberatePage({ initialDebates }) {
             }}
         >
             <NavBar />
+            <NextSeo
+                title="Deliberate - Bicker"
+                description="Vote on debates and see how others feel."/>
 
             {/* Fullscreen Debate Section */}
             <div style={{ 

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -1,0 +1,42 @@
+import { NextSeo } from 'next-seo';
+import NavBar from '../../components/NavBar';
+
+export default function DeliberateDetail({ deliberation }) {
+  if (!deliberation) {
+    return <div>Deliberation not found</div>;
+  }
+
+  return (
+    <div style={{ paddingTop: '70px', fontFamily: 'Arial, sans-serif' }}>
+      <NextSeo
+        title={`Deliberation: ${deliberation.instigateText}`}
+        description={deliberation.debateText}
+        canonical={`https://www.yoursite.com/deliberates/${deliberation._id}`}
+        openGraph={{
+          url: `https://www.yoursite.com/deliberates/${deliberation._id}`,
+          title: `Deliberation: ${deliberation.instigateText}`,
+          description: deliberation.debateText,
+        }}
+      />
+      <NavBar />
+      <h1 style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
+      <p style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ params, req }) {
+  const protocol = req.headers["x-forwarded-proto"] || "http";
+  const baseUrl = `${protocol}://${req.headers.host}`;
+  try {
+    const res = await fetch(`${baseUrl}/api/deliberate/${params.id}`);
+    if (!res.ok) {
+      return { notFound: true };
+    }
+    const deliberation = await res.json();
+    return { props: { deliberation } };
+  } catch (error) {
+    console.error('Failed to load deliberation:', error);
+    return { props: { deliberation: null } };
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.yoursite.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.yoursite.com/</loc>
+  </url>
+  <url>
+    <loc>https://www.yoursite.com/debate</loc>
+  </url>
+  <url>
+    <loc>https://www.yoursite.com/deliberate</loc>
+  </url>
+  <url>
+    <loc>https://www.yoursite.com/leaderboard</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- enhance site metadata
- expose single debate and deliberation API routes
- add detail pages for debates and deliberations
- link leaderboard items to debate pages
- include sitemap and robots rules

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686838658a14832dad197c7b65f8cfa9