### PR TITLE
Add totals and text-bubble style to leaderboard

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -4,6 +4,8 @@ import NavBar from '../components/NavBar';
 export default function Leaderboard() {
   const [debates, setDebates] = useState([]);
   const [sort, setSort] = useState('newest');
+  const [totalVotes, setTotalVotes] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const fetchDebates = async () => {
@@ -12,6 +14,7 @@ export default function Leaderboard() {
         if (!res.ok) throw new Error('Failed to fetch debates');
         const data = await res.json();
         setDebates(data.debates || []);
+        setTotalVotes(data.totalVotes || 0);
       } catch (err) {
         console.error('Error fetching debates:', err);
       }
@@ -19,11 +22,23 @@ export default function Leaderboard() {
     fetchDebates();
   }, [sort]);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
       <NavBar />
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
-        <h1 style={{ textAlign: 'center', marginBottom: '20px' }}>Debate Leaderboard</h1>
+        <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
+        <p style={{ textAlign: 'center', marginBottom: '20px' }}>
+          Total Debates: {debates.length} | Total Votes: {totalVotes}
+        </p>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
             <option value="newest">Newest First</option>
@@ -33,10 +48,44 @@ export default function Leaderboard() {
           </select>
         </div>
         {debates.map((debate) => (
-          <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '15px' }}>
-            <p style={{ margin: '0 0 8px 0', fontWeight: 'bold' }}>{debate.instigateText}</p>
-            <p style={{ margin: '0 0 8px 0' }}>{debate.debateText}</p>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div
+                style={{
+                  alignSelf: 'flex-start',
+                  maxWidth: isMobile ? '80%' : '60%',
+                  backgroundColor: '#FF4D4D',
+                  color: 'white',
+                  padding: '12px 16px',
+                  borderRadius: '16px',
+                  borderTopLeftRadius: '4px',
+                  marginLeft: 0,
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
+                }}
+              >
+                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                  {debate.instigateText}
+                </p>
+              </div>
+              <div
+                style={{
+                  alignSelf: 'flex-end',
+                  maxWidth: isMobile ? '80%' : '60%',
+                  backgroundColor: '#4D94FF',
+                  color: 'white',
+                  padding: '12px 16px',
+                  borderRadius: '16px',
+                  borderTopRightRadius: '4px',
+                  marginRight: 0,
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
+                }}
+              >
+                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                  {debate.debateText}
+                </p>
+              </div>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
               <span style={{ color: '#FF4D4D' }}>Red Votes: {debate.votesRed || 0}</span>
               <span style={{ color: '#4D94FF' }}>Blue Votes: {debate.votesBlue || 0}</span>
             </div>


### PR DESCRIPTION
## Summary
- show total debate and vote counts
- style leaderboard debates with red/blue text bubbles
- keep layout responsive on mobile

## Testing
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686abae37d80832db2ec36d40de39e00