### PR TITLE
Improve mobile layout

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon_io/android-chrome-512x512.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon_io/android-chrome-192x192.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon_io/favicon-32x32.png" />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,19 @@
 import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
 import NavBar from '../components/NavBar';
 
 export default function Home() {
     const router = useRouter();
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth <= 768);
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     // Whether user is signed in or not, we show the main content
     return (
@@ -18,7 +29,13 @@ export default function Home() {
             <NavBar />
 
             {/* Split Screen */}
-            <div style={{ display: 'flex', height: '100%' }}>
+            <div
+                style={{
+                    display: 'flex',
+                    height: '100%',
+                    flexDirection: isMobile ? 'column' : 'row',
+                }}
+            >
                 {/* Left Side - Instigate */}
                 <div
                     onClick={() => router.push('/instigate')}
@@ -31,11 +48,19 @@ export default function Home() {
                         alignItems: 'center',
                         cursor: 'pointer',
                         transition: 'background-color 0.3s ease',
+                        width: isMobile ? '100%' : '50%',
+                        height: isMobile ? '50%' : '100%',
                     }}
                     onMouseEnter={(e) => (e.target.style.backgroundColor = '#FF6A6A')}
                     onMouseLeave={(e) => (e.target.style.backgroundColor = '#FF4D4D')}
                 >
-                    <h1 style={{ fontSize: '36px', textAlign: 'center', margin: '0 20px' }}>
+                    <h1
+                        style={{
+                            fontSize: isMobile ? '28px' : '36px',
+                            textAlign: 'center',
+                            margin: '0 20px',
+                        }}
+                    >
                         Instigate
                         <br />
                         Click to Begin
@@ -54,11 +79,19 @@ export default function Home() {
                         alignItems: 'center',
                         cursor: 'pointer',
                         transition: 'background-color 0.3s ease',
+                        width: isMobile ? '100%' : '50%',
+                        height: isMobile ? '50%' : '100%',
                     }}
                     onMouseEnter={(e) => (e.target.style.backgroundColor = '#76ACFF')}
                     onMouseLeave={(e) => (e.target.style.backgroundColor = '#4D94FF')}
                 >
-                    <h1 style={{ fontSize: '36px', textAlign: 'center', margin: '0 20px' }}>
+                    <h1
+                        style={{
+                            fontSize: isMobile ? '28px' : '36px',
+                            textAlign: 'center',
+                            margin: '0 20px',
+                        }}
+                    >
                         Debate
                         <br />
                         Click to Join


### PR DESCRIPTION
## Summary
- tweak layout on the home page for smaller screens
- add viewport meta tag for better mobile scaling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686acfc55280832d931fe869ef24c700