### PR TITLE
Improve divisive/decisive sort

### DIFF
--- a/pages/api/debates/stats.js
+++ b/pages/api/debates/stats.js
@@ -21,21 +21,27 @@ export default async function handler(req, res) {
                 (a, b) => (b.votesRed + b.votesBlue) - (a.votesRed + a.votesBlue)
             );
         } else if (sort === 'mostDivisive') {
-            // Sort by closest split (difference ratio near 0)
+            // Sort by closest split with more votes taking precedence
             debates.sort((a, b) => {
                 const totalA = a.votesRed + a.votesBlue;
                 const totalB = b.votesRed + b.votesBlue;
-                const ratioA = Math.abs(a.votesRed - a.votesBlue) / totalA;
-                const ratioB = Math.abs(b.votesRed - b.votesBlue) / totalB;
+                const ratioA = totalA === 0 ? Infinity : Math.abs(a.votesRed - a.votesBlue) / totalA;
+                const ratioB = totalB === 0 ? Infinity : Math.abs(b.votesRed - b.votesBlue) / totalB;
+                if (ratioA === ratioB) {
+                    return totalB - totalA; // more total votes first when equally divisive
+                }
                 return ratioA - ratioB; // smaller ratio => more divisive
             });
         } else if (sort === 'mostDecisive') {
-            // Sort by most lopsided (largest ratio)
+            // Sort by most lopsided with more votes taking precedence
             debates.sort((a, b) => {
                 const totalA = a.votesRed + a.votesBlue;
                 const totalB = b.votesRed + b.votesBlue;
-                const ratioA = Math.abs(a.votesRed - a.votesBlue) / totalA;
-                const ratioB = Math.abs(b.votesRed - b.votesBlue) / totalB;
+                const ratioA = totalA === 0 ? 0 : Math.abs(a.votesRed - a.votesBlue) / totalA;
+                const ratioB = totalB === 0 ? 0 : Math.abs(b.votesRed - b.votesBlue) / totalB;
+                if (ratioA === ratioB) {
+                    return totalB - totalA; // more total votes first when ratio equal
+                }
                 return ratioB - ratioA; // bigger ratio => more decisive
             });
         }


### PR DESCRIPTION
## Summary
- update `mostDivisive` and `mostDecisive` sorting logic so ties are ordered by total votes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687579e67428832d8354f050cc80171d