### PR TITLE
Add pagination to leaderboard

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -4,23 +4,28 @@ import NavBar from '../components/NavBar';
 export default function Leaderboard() {
   const [debates, setDebates] = useState([]);
   const [sort, setSort] = useState('newest');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalDebates, setTotalDebates] = useState(0);
   const [totalVotes, setTotalVotes] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const fetchDebates = async () => {
       try {
-        const res = await fetch(`/api/debates/stats?sort=${sort}`);
+        const res = await fetch(`/api/debates/stats?sort=${sort}&page=${page}`);
         if (!res.ok) throw new Error('Failed to fetch debates');
         const data = await res.json();
         setDebates(data.debates || []);
         setTotalVotes(data.totalVotes || 0);
+        setTotalDebates(data.totalDebates || 0);
+        setTotalPages(Math.ceil((data.totalDebates || 0) / 25) || 1);
       } catch (err) {
         console.error('Error fetching debates:', err);
       }
     };
     fetchDebates();
-  }, [sort]);
+  }, [sort, page]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -37,7 +42,7 @@ export default function Leaderboard() {
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
         <p style={{ textAlign: 'center', marginBottom: '20px' }}>
-          Total Debates: {debates.length} | Total Votes: {totalVotes}
+          Total Debates: {totalDebates} | Total Votes: {totalVotes}
         </p>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
@@ -91,6 +96,15 @@ export default function Leaderboard() {
             </div>
           </div>
         ))}
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
+          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
+            Prev
+          </button>
+          <span>Page {page} of {totalPages}</span>
+          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+            Next
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement pagination support in `/api/debates/stats`
- add page navigation and counts on `leaderboard` page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875b4d32140832d897ade8efa1a7044