### PR TITLE
Enable Google sign‑in with personal stats

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,7 +1,9 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 export default function NavBar() {
+    const { data: session } = useSession();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const [isMobile, setIsMobile] = useState(false);
 
@@ -149,6 +151,7 @@ export default function NavBar() {
                         { label: 'Debate', path: '/debate' },
                         { label: 'Deliberate', path: '/deliberate' },
                         { label: 'Leaderboard', path: '/leaderboard' },
+                        ...(session ? [{ label: 'My Stats', path: '/my-stats' }] : [])
                     ].map(({ label, path }) => (
                         <Link key={label} href={path} passHref>
                             <button
@@ -160,7 +163,25 @@ export default function NavBar() {
                             </button>
                         </Link>
                     ))}
-                    {/* Sign in/out removed */}
+                    {session ? (
+                        <button
+                            style={buttonStyle}
+                            onMouseEnter={handleMouseEnter}
+                            onMouseLeave={handleMouseLeave}
+                            onClick={() => signOut()}
+                        >
+                            Sign Out
+                        </button>
+                    ) : (
+                        <button
+                            style={buttonStyle}
+                            onMouseEnter={handleMouseEnter}
+                            onMouseLeave={handleMouseLeave}
+                            onClick={() => signIn('google')}
+                        >
+                            Sign In
+                        </button>
+                    )}
                 </>
             )}
 
@@ -186,6 +207,7 @@ export default function NavBar() {
                 { label: 'Debate', path: '/debate' },
                 { label: 'Deliberate', path: '/deliberate' },
                 { label: 'Leaderboard', path: '/leaderboard' },
+                ...(session ? [{ label: 'My Stats', path: '/my-stats' }] : [])
             ].map(({ label, path }) => (
                 <Link key={label} href={path} passHref>
                     <button
@@ -202,7 +224,21 @@ export default function NavBar() {
                     </button>
                 </Link>
             ))}
-            {/* Authentication buttons removed */}
+            {session ? (
+                <button
+                    style={{ ...buttonStyle, width: '100%', marginTop: '10px' }}
+                    onClick={() => { setIsMobileMenuOpen(false); signOut(); }}
+                >
+                    Sign Out
+                </button>
+            ) : (
+                <button
+                    style={{ ...buttonStyle, width: '100%', marginTop: '10px' }}
+                    onClick={() => { setIsMobileMenuOpen(false); signIn('google'); }}
+                >
+                    Sign In
+                </button>
+            )}
                 </div>
             )}
         </nav>

--- a/models/Deliberate.js
+++ b/models/Deliberate.js
@@ -12,6 +12,10 @@ const DeliberateSchema = new mongoose.Schema({
         required: true,
         maxlength: 200,
     },
+    createdBy: {
+        type: String,
+        default: 'anonymous'
+    },
     votesRed: {
         type: Number,
         default: 0

--- a/pages/api/debate.js
+++ b/pages/api/debate.js
@@ -2,6 +2,8 @@ import dbConnect from '../../lib/dbConnect';
 import Debate from '../../models/Debate';
 import Instigate from '../../models/Instigate';
 import Deliberate from '../../models/Deliberate';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req, res) {
     await dbConnect();
@@ -44,18 +46,21 @@ export default async function handler(req, res) {
                 return res.status(404).json({ error: 'Instigate not found' });
             }
 
+            const session = await getServerSession(req, res, authOptions);
+            const creator = session?.user?.email || 'anonymous';
+
             // 2) Create the Debate
             const newDebate = await Debate.create({
                 instigateText: instigate.text,
                 debateText: debateText.trim(),
-                createdBy: 'anonymous'
+                createdBy: creator
             });
 
             // 3) Create a Deliberate doc with the same text
             await Deliberate.create({
                 instigateText: instigate.text,
                 debateText: debateText.trim(),
-                createdBy: 'anonymous',
+                createdBy: creator,
                 votesRed: 0,
                 votesBlue: 0,
                 votedBy: []

--- a/pages/api/deliberate.js
+++ b/pages/api/deliberate.js
@@ -1,5 +1,7 @@
 import dbConnect from '../../lib/dbConnect';
 import Deliberate from '../../models/Deliberate';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req, res) {
     try {
@@ -47,10 +49,13 @@ export default async function handler(req, res) {
                 deliberation.votesBlue = (deliberation.votesBlue || 0) + 1;
             }
 
+            const session = await getServerSession(req, res, authOptions);
+            const voter = session?.user?.email || 'anonymous';
+
             // Add user's vote to votedBy array
             deliberation.votedBy = deliberation.votedBy || [];
             deliberation.votedBy.push({
-                userId: 'anonymous',
+                userId: voter,
                 vote: vote,
                 timestamp: new Date()
             });

--- a/pages/api/user/debates.js
+++ b/pages/api/user/debates.js
@@ -1,0 +1,25 @@
+import dbConnect from '../../../lib/dbConnect';
+import Deliberate from '../../../models/Deliberate';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+    await dbConnect();
+    try {
+        const userId = session.user.email;
+        const debates = await Deliberate.find({
+            $or: [
+                { createdBy: userId },
+                { 'votedBy.userId': userId }
+            ]
+        }).lean();
+        return res.status(200).json({ debates });
+    } catch (e) {
+        console.error('Error fetching user debates:', e);
+        return res.status(500).json({ error: 'Failed to fetch user debates' });
+    }
+}

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import NavBar from '../components/NavBar';
+
+export default function MyStats() {
+  const { data: session } = useSession();
+  const [debates, setDebates] = useState([]);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (!session) return;
+    const fetchDebates = async () => {
+      try {
+        const res = await fetch('/api/user/debates');
+        if (!res.ok) throw new Error('Failed to fetch debates');
+        const data = await res.json();
+        setDebates(data.debates || []);
+      } catch (err) {
+        console.error('Error fetching user debates:', err);
+      }
+    };
+    fetchDebates();
+  }, [session]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  if (!session) {
+    return (
+      <div style={{ paddingTop: '60px', textAlign: 'center' }}>
+        <NavBar />
+        <h2>Please sign in to view your stats.</h2>
+        <button onClick={() => signIn('google')}>Sign In with Google</button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
+      <NavBar />
+      <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
+        {debates.map((debate) => (
+          <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div style={{ alignSelf: 'flex-start', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#FF4D4D', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopLeftRadius: '4px', marginLeft: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
+                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                  {debate.instigateText}
+                </p>
+              </div>
+              <div style={{ alignSelf: 'flex-end', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#4D94FF', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopRightRadius: '4px', marginRight: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
+                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                  {debate.debateText}
+                </p>
+              </div>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
+              <span style={{ color: '#FF4D4D' }}>Red Votes: {debate.votesRed || 0}</span>
+              <span style={{ color: '#4D94FF' }}>Blue Votes: {debate.votesBlue || 0}</span>
+            </div>
+          </div>
+        ))}
+        {debates.length === 0 && (
+          <p style={{ textAlign: 'center' }}>You have not participated in any debates yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth into the NavBar with Google sign in/out
- track user ID when creating debates or voting
- add `createdBy` field to `Deliberate` model
- provide `/api/user/debates` endpoint for signed-in users
- create `my-stats` page showing a user's debates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879182d9fd4832da242f18d206602d8