### PR TITLE
Fix stats page to only show authored debates

### DIFF
--- a/pages/api/user/debates.js
+++ b/pages/api/user/debates.js
@@ -12,10 +12,7 @@ export default async function handler(req, res) {
     try {
         const userId = session.user.email;
         const debates = await Deliberate.find({
-            $or: [
-                { createdBy: userId },
-                { 'votedBy.userId': userId }
-            ]
+            createdBy: userId
         }).lean();
         return res.status(200).json({ debates });
     } catch (e) {

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -16,22 +16,20 @@ export default function MyStats() {
 
   const totalParticipated = debates.length;
   let wins = 0;
-  let writtenCount = 0;
   processedDebates.forEach((d) => {
-    if (d.userWroteSide) {
-      writtenCount += 1;
-      const winningSide =
-        d.votesRed === d.votesBlue
-          ? null
-          : d.votesRed > d.votesBlue
-          ? 'red'
-          : 'blue';
-      if (winningSide && d.userWroteSide === winningSide) {
-        wins += 1;
-      }
+    const winningSide =
+      d.votesRed === d.votesBlue
+        ? null
+        : d.votesRed > d.votesBlue
+        ? 'red'
+        : 'blue';
+    if (winningSide === 'blue') {
+      wins += 1;
     }
   });
-  const winRate = writtenCount ? ((wins / writtenCount) * 100).toFixed(0) : '0';
+  const winRate = totalParticipated
+    ? ((wins / totalParticipated) * 100).toFixed(0)
+    : '0';
 
   useEffect(() => {
     if (!session) return;


### PR DESCRIPTION
## Summary
- update `/api/user/debates` to only return debates written by the logged in user
- adjust MyStats page win rate calculation and only count authored debates

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e6bf93a94832db3cab68de350670e