### PR TITLE
Fix mobile nav sign-in button alignment

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -225,14 +225,26 @@ export default function NavBar() {
             ))}
             {session ? (
                 <button
-                    style={{ ...buttonStyle, width: '100%', marginTop: '10px' }}
+                    style={{
+                        ...buttonStyle,
+                        width: '100%',
+                        margin: '5px 0',
+                        padding: '15px 20px',
+                        fontSize: '18px'
+                    }}
                     onClick={() => { setIsMobileMenuOpen(false); signOut(); }}
                 >
                     Sign Out
                 </button>
             ) : (
                 <button
-                    style={{ ...buttonStyle, width: '100%', marginTop: '10px' }}
+                    style={{
+                        ...buttonStyle,
+                        width: '100%',
+                        margin: '5px 0',
+                        padding: '15px 20px',
+                        fontSize: '18px'
+                    }}
                     onClick={() => { setIsMobileMenuOpen(false); signIn('google'); }}
                 >
                     Sign In


### PR DESCRIPTION
## Summary
- Align mobile Sign In/Out button with other navigation items

## Testing
- `npm test` *(fails: Missing script "test"*`

------
https://chatgpt.com/codex/tasks/task_e_688da1bb355c832db886a9b92ccdec3a