### PR TITLE
feat: widen mobile submit button

### DIFF
--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -108,6 +108,7 @@ export default function InstigatePage() {
                     </div>
                 </div>
                 <button
+                    className="submit-topic-button"
                     onClick={submitInstigate}
                     style={{
                         width: '50%',
@@ -134,6 +135,14 @@ export default function InstigatePage() {
                 >
                     Submit Topic
                 </button>
+                <style jsx>{`
+                    @media (max-width: 480px) {
+                        .submit-topic-button {
+                            width: 100% !important;
+                            white-space: nowrap;
+                        }
+                    }
+                `}</style>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- widen `Submit Topic` button on mobile to keep text on a single line

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da5080184832d96910d246071f5af