### PR TITLE
Enhance SEO metadata and sitemap

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,18 +1,32 @@
 export default {
   title: 'Bicker',
   description: 'The game of instigating, debating, and deliberating!',
+  canonical: 'https://bicker.ca/',
   additionalMetaTags: [
     {
       name: 'keywords',
       content:
         'bicker, debate, deliberate, instigate, online debate game',
     },
+    { name: 'robots', content: 'index, follow' },
   ],
   openGraph: {
     type: 'website',
     locale: 'en_US',
     url: 'https://bicker.ca/',
     site_name: 'Bicker',
+    images: [
+      {
+        url: 'https://bicker.ca/favicon_io/android-chrome-512x512.png',
+        width: 512,
+        height: 512,
+        alt: 'Bicker Logo',
+      },
+    ],
+  },
+
+  twitter: {
+    cardType: 'summary_large_image',
   },
 
 };

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,6 +10,12 @@
     <loc>https://bicker.ca/deliberate</loc>
   </url>
   <url>
+    <loc>https://bicker.ca/instigate</loc>
+  </url>
+  <url>
     <loc>https://bicker.ca/leaderboard</loc>
+  </url>
+  <url>
+    <loc>https://bicker.ca/my-stats</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- enrich default SEO config with canonical URL, robots directive, Open Graph image, and Twitter card settings
- expand sitemap to list additional static pages for better indexing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953e05186c832da5e5a8bbfa3e57d6