### PR TITLE
Center debate text box on mobile

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -407,6 +407,7 @@ export default function DebatePage({ initialDebates }) {
                         style={{
                             position: 'relative',
                             width: isMobile ? '85%' : '60%',
+                            margin: '0 auto',
                         }}
                     >
                         <textarea
@@ -425,8 +426,8 @@ export default function DebatePage({ initialDebates }) {
                                 color: 'black',
                                 resize: 'none',
                                 overflow: 'hidden',
-                                marginLeft: 'auto',
-                                marginRight: 'auto',
+                                boxSizing: 'border-box',
+                                margin: '0 auto',
                             }}
                         />
                         <div


### PR DESCRIPTION
## Summary
- Center debate textarea on mobile by adding auto margins and border-box sizing.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895416d5f9c832d8442614d60475433