### PR TITLE
Track instigator so topics count in user stats

### DIFF
--- a/models/Debate.js
+++ b/models/Debate.js
@@ -15,6 +15,10 @@ const DebateSchema = new mongoose.Schema({
     createdBy: {
         type: String,
         required: true
+    },
+    instigatedBy: {
+        type: String,
+        default: 'anonymous'
     }
 }, { timestamps: true });
 

--- a/models/Deliberate.js
+++ b/models/Deliberate.js
@@ -16,6 +16,10 @@ const DeliberateSchema = new mongoose.Schema({
         type: String,
         default: 'anonymous'
     },
+    instigatedBy: {
+        type: String,
+        default: 'anonymous'
+    },
     votesRed: {
         type: Number,
         default: 0

--- a/models/Instigate.js
+++ b/models/Instigate.js
@@ -8,6 +8,10 @@ const InstigateSchema = new mongoose.Schema(
             required: true,
             maxlength: 200,
         },
+        createdBy: {
+            type: String,
+            default: 'anonymous',
+        },
     },
     { timestamps: true } // adds createdAt, updatedAt automatically
 );

--- a/pages/api/debate.js
+++ b/pages/api/debate.js
@@ -49,12 +49,14 @@ export default async function handler(req, res) {
 
             const session = await getServerSession(req, res, authOptions);
             const creator = session?.user?.email || 'anonymous';
+            const instigator = instigate.createdBy || 'anonymous';
 
             // 2) Create the Debate
             const newDebate = await Debate.create({
                 instigateText: instigate.text,
                 debateText: debateText.trim(),
-                createdBy: creator
+                createdBy: creator,
+                instigatedBy: instigator
             });
 
             // Notify the creator that their debate was created
@@ -68,6 +70,7 @@ export default async function handler(req, res) {
                 instigateText: instigate.text,
                 debateText: debateText.trim(),
                 createdBy: creator,
+                instigatedBy: instigator,
                 votesRed: 0,
                 votesBlue: 0,
                 votedBy: []

--- a/pages/api/instigate.js
+++ b/pages/api/instigate.js
@@ -1,18 +1,22 @@
 import dbConnect from '../../lib/dbConnect';
 import Instigate from '../../models/Instigate';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req, res) {
     await dbConnect();
 
     if (req.method === 'POST') {
         const { text } = req.body;
+        const session = await getServerSession(req, res, authOptions);
+        const creator = session?.user?.email || 'anonymous';
         if (!text || text.length > 200) {
             return res
                 .status(400)
                 .json({ error: 'Text is required and must be under 200 characters.' });
         }
         try {
-            const newInstigate = await Instigate.create({ text });
+            const newInstigate = await Instigate.create({ text, createdBy: creator });
             return res.status(201).json(newInstigate);
         } catch (error) {
             console.error('Error creating instigate:', error);

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -15,7 +15,7 @@ export default function MyStats() {
 
   const processedDebates = debates.map((debate) => {
     const vote = debate.votedBy?.find((v) => v.userId === userId);
-    const wroteSide = debate.createdBy === userId ? 'blue' : null;
+    const wroteSide = debate.createdBy === userId ? 'blue' : (debate.instigatedBy === userId ? 'red' : null);
     return { ...debate, userSide: vote ? vote.vote : null, userWroteSide: wroteSide };
   });
 


### PR DESCRIPTION
## Summary
- Track who instigated a topic and store it alongside the text
- Propagate instigator info when creating debates and deliberations
- Show instigated debates in user stats and win calculations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895678c4204832db896704d0be222c4