### PR TITLE
Add tagging and trending features

### DIFF
--- a/models/Instigate.js
+++ b/models/Instigate.js
@@ -12,6 +12,10 @@ const InstigateSchema = new mongoose.Schema(
             type: String,
             default: 'anonymous',
         },
+        tags: {
+            type: [String],
+            default: [],
+        },
     },
     { timestamps: true } // adds createdAt, updatedAt automatically
 );

--- a/pages/api/trending.js
+++ b/pages/api/trending.js
@@ -1,0 +1,20 @@
+import dbConnect from '../../lib/dbConnect';
+import Instigate from '../../models/Instigate';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  try {
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // last 7 days
+    const trending = await Instigate.aggregate([
+      { $match: { createdAt: { $gte: since }, tags: { $exists: true, $ne: [] } } },
+      { $unwind: '$tags' },
+      { $group: { _id: '$tags', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 10 },
+    ]);
+    return res.status(200).json(trending);
+  } catch (error) {
+    console.error('Error fetching trending tags:', error);
+    return res.status(500).json({ error: 'Failed to fetch trending tags.' });
+  }
+}

--- a/pages/debate.js
+++ b/pages/debate.js
@@ -15,6 +15,8 @@ export default function DebatePage({ initialDebates }) {
     const [showSearchResults, setShowSearchResults] = useState(false);
     // Toggle search bar expansion
     const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+    const [tagFilter, setTagFilter] = useState('');
+    const [trendingTags, setTrendingTags] = useState([]);
 
     useEffect(() => {
         const checkMobile = () => {
@@ -42,11 +44,30 @@ export default function DebatePage({ initialDebates }) {
         }
     }, [initialDebates]);
 
-    const fetchInstigates = async (search = '') => {
+    useEffect(() => {
+        const loadTrending = async () => {
+            try {
+                const res = await fetch('/api/trending');
+                const data = await res.json();
+                setTrendingTags(data);
+            } catch (error) {
+                console.error('Error fetching trending tags:', error);
+            }
+        };
+        loadTrending();
+    }, []);
+
+    useEffect(() => {
+        fetchInstigates('', tagFilter);
+    }, [tagFilter]);
+
+    const fetchInstigates = async (search = '', tag = '') => {
         try {
-            const url = search
-                ? `/api/instigate?search=${encodeURIComponent(search)}`
-                : `/api/instigate`;
+            let url = '/api/instigate';
+            const params = [];
+            if (search) params.push(`search=${encodeURIComponent(search)}`);
+            if (tag) params.push(`tags=${encodeURIComponent(tag)}`);
+            if (params.length) url += `?${params.join('&')}`;
             const response = await fetch(url);
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
@@ -70,13 +91,15 @@ export default function DebatePage({ initialDebates }) {
         const delayDebounceFn = setTimeout(async () => {
             if (searchTerm.trim()) {
                 try {
-                    const response = await fetch(
-                        `/api/instigate?search=${encodeURIComponent(searchTerm)}`
-                    );
+                    let url = `/api/instigate?search=${encodeURIComponent(searchTerm)}`;
+                    if (tagFilter.trim()) {
+                        url += `&tags=${encodeURIComponent(tagFilter)}`;
+                    }
+                    const response = await fetch(url);
                     if (!response.ok)
                         throw new Error(`HTTP error! status: ${response.status}`);
                     const results = await response.json();
-                    
+
                     const resultsWithDebates = await Promise.all(
                         results.slice(0, 5).map(async (instigate) => {
                             const debateResponse = await fetch(
@@ -100,11 +123,17 @@ export default function DebatePage({ initialDebates }) {
             }
         }, 300);
         return () => clearTimeout(delayDebounceFn);
-    }, [searchTerm]);
+    }, [searchTerm, tagFilter]);
 
     const selectSearchResult = (instigate) => {
         setInstigates([instigate, ...instigates]);
-        setCurrentInstigateIndex(0);
+       setCurrentInstigateIndex(0);
+       setSearchTerm('');
+       setShowSearchResults(false);
+    };
+
+    const handleTagClick = (tag) => {
+        setTagFilter(tag);
         setSearchTerm('');
         setShowSearchResults(false);
     };
@@ -217,6 +246,23 @@ export default function DebatePage({ initialDebates }) {
                 </div>
     );
 
+    const tagInput = (
+        <input
+            type="text"
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            placeholder="Filter by tag"
+            style={{
+                width: '100%',
+                marginTop: '10px',
+                padding: '8px',
+                fontSize: '16px',
+                borderRadius: '8px',
+                border: '1px solid #ccc',
+            }}
+        />
+    );
+
     const searchResultsList =
         showSearchResults && searchResults.length > 0 ? (
             <div
@@ -251,6 +297,36 @@ export default function DebatePage({ initialDebates }) {
                 ))}
             </div>
         ) : null;
+
+    const trendingSection = (
+        <div style={{ marginTop: '10px', textAlign: 'center' }}>
+            <h4 style={{ margin: '10px 0', color: '#333' }}>Trending</h4>
+            <div
+                style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '8px',
+                    justifyContent: 'center',
+                }}
+            >
+                {trendingTags.map((tag) => (
+                    <span
+                        key={tag._id}
+                        onClick={() => handleTagClick(tag._id)}
+                        style={{
+                            backgroundColor: '#007BFF',
+                            color: '#fff',
+                            padding: '4px 8px',
+                            borderRadius: '4px',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        {tag._id} ({tag.count})
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
 
     return (
         <div
@@ -292,7 +368,9 @@ export default function DebatePage({ initialDebates }) {
                     }}
                 >
                     {searchBarContent}
+                    {tagInput}
                     {searchResultsList}
+                    {trendingSection}
                 </div>
             )}
 
@@ -342,7 +420,9 @@ export default function DebatePage({ initialDebates }) {
                         }}
                     >
                         {searchBarContent}
+                        {tagInput}
                         {searchResultsList}
+                        {trendingSection}
                     </div>
                 )}
 

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -5,6 +5,7 @@ import NavBar from '../components/NavBar';
 export default function InstigatePage() {
     const [instigates, setInstigates] = useState([]);
     const [newInstigate, setNewInstigate] = useState('');
+    const [tags, setTags] = useState('');
 
     // Disable scrolling on mount
     useEffect(() => {
@@ -39,9 +40,16 @@ export default function InstigatePage() {
             await fetch('/api/instigate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ text: newInstigate }),
+                body: JSON.stringify({
+                    text: newInstigate,
+                    tags: tags
+                        .split(',')
+                        .map((t) => t.trim())
+                        .filter((t) => t),
+                }),
             });
             setNewInstigate('');
+            setTags('');
             fetchInstigates();
         } catch (error) {
             console.error('Error submitting instigate:', error);
@@ -107,6 +115,20 @@ export default function InstigatePage() {
                         {newInstigate.length}/200
                     </div>
                 </div>
+                <input
+                    type="text"
+                    value={tags}
+                    onChange={(e) => setTags(e.target.value)}
+                    placeholder="Add tags separated by commas"
+                    style={{
+                        width: '100%',
+                        marginTop: '10px',
+                        padding: '8px',
+                        fontSize: '18px',
+                        borderRadius: '4px',
+                        border: '1px solid #ccc',
+                    }}
+                />
                 <button
                     className="submit-topic-button"
                     onClick={submitInstigate}

--- a/pages/tags/[tag].js
+++ b/pages/tags/[tag].js
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import NavBar from '../../components/NavBar';
+
+export default function TagPage() {
+  const router = useRouter();
+  const { tag } = router.query;
+  const [instigates, setInstigates] = useState([]);
+
+  useEffect(() => {
+    if (tag) {
+      fetchByTag(tag);
+    }
+  }, [tag]);
+
+  const fetchByTag = async (t) => {
+    try {
+      const res = await fetch(`/api/instigate?tags=${encodeURIComponent(t)}`);
+      const instigs = await res.json();
+      const withDebates = await Promise.all(
+        instigs.map(async (inst) => {
+          const resp = await fetch(`/api/debate?instigateId=${inst._id}`);
+          const debates = await resp.json();
+          return { ...inst, debates: debates || [] };
+        })
+      );
+      setInstigates(withDebates);
+    } catch (err) {
+      console.error('Error loading tag', err);
+    }
+  };
+
+  return (
+    <div style={{ paddingTop: '70px', fontFamily: 'Arial, sans-serif' }}>
+      <NavBar />
+      <h1 style={{ textAlign: 'center' }}>Tag: {tag}</h1>
+      {instigates.map((inst) => (
+        <div
+          key={inst._id}
+          style={{
+            margin: '20px auto',
+            maxWidth: '600px',
+            padding: '10px',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            backgroundColor: '#fff',
+          }}
+        >
+          <h3>{inst.text}</h3>
+          <ul>
+            {inst.debates.map((debate) => (
+              <li key={debate._id}>{debate.debateText}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Support tags on instigates and expose them via API
- Allow adding tags when submitting instigates
- Filter debates by tag, surface trending tags, and provide tag browsing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689578ee7cc8832d83dbcd8b66babf2d