### PR TITLE
Add badge rules and update badge helper

### DIFF
--- a/lib/badgeHelper.js
+++ b/lib/badgeHelper.js
@@ -1,0 +1,36 @@
+import User from '../models/User';
+import Debate from '../models/Debate';
+import Instigate from '../models/Instigate';
+import badgeRules from './badgeRules';
+
+export default async function updateBadges(email) {
+    if (!email || email === 'anonymous') return [];
+
+    const user = await User.findOne({ email });
+    if (!user) return [];
+
+    const [debates, instigates] = await Promise.all([
+        Debate.countDocuments({ createdBy: email }),
+        Instigate.countDocuments({ createdBy: email })
+    ]);
+
+    const stats = {
+        points: user.points || 0,
+        streak: user.streak || 0,
+        debates,
+        instigates
+    };
+
+    const earned = badgeRules
+        .filter(rule => rule.condition(stats))
+        .map(rule => rule.name);
+
+    const newBadges = earned.filter(name => !user.badges.includes(name));
+
+    if (newBadges.length) {
+        user.badges = [...user.badges, ...newBadges];
+        await user.save();
+    }
+
+    return newBadges;
+}

--- a/lib/badgeRules.js
+++ b/lib/badgeRules.js
@@ -1,0 +1,20 @@
+const badgeRules = [
+    {
+        name: 'First Debate',
+        condition: (stats) => stats.debates >= 1
+    },
+    {
+        name: 'First Instigate',
+        condition: (stats) => stats.instigates >= 1
+    },
+    {
+        name: '10 Points',
+        condition: (stats) => stats.points >= 10
+    },
+    {
+        name: '5-Day Streak',
+        condition: (stats) => stats.streak >= 5
+    }
+];
+
+export default badgeRules;

--- a/pages/api/debate.js
+++ b/pages/api/debate.js
@@ -6,6 +6,7 @@ import Notification from '../../models/Notification';
 import User from '../../models/User';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
+import updateBadges from '../../lib/badgeHelper';
 
 export default async function handler(req, res) {
     await dbConnect();
@@ -65,6 +66,7 @@ export default async function handler(req, res) {
                     { email: creator },
                     { $inc: { points: 1, streak: 1 } }
                 );
+                await updateBadges(creator);
             }
 
             // Notify the creator that their debate was created

--- a/pages/api/deliberate.js
+++ b/pages/api/deliberate.js
@@ -4,6 +4,7 @@ import Notification from '../../models/Notification';
 import User from '../../models/User';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
+import updateBadges from '../../lib/badgeHelper';
 
 export default async function handler(req, res) {
     try {
@@ -71,6 +72,7 @@ export default async function handler(req, res) {
                     { email: voter },
                     { $inc: { points: 1, streak: 1 } }
                 );
+                await updateBadges(voter);
             }
 
             // Notify the creator of the debate about the new vote

--- a/pages/api/instigate.js
+++ b/pages/api/instigate.js
@@ -2,6 +2,7 @@ import dbConnect from '../../lib/dbConnect';
 import Instigate from '../../models/Instigate';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
+import updateBadges from '../../lib/badgeHelper';
 
 export default async function handler(req, res) {
     await dbConnect();
@@ -15,8 +16,9 @@ export default async function handler(req, res) {
                 .status(400)
                 .json({ error: 'Text is required and must be under 200 characters.' });
         }
-        try {
+            try {
             const newInstigate = await Instigate.create({ text, createdBy: creator });
+            await updateBadges(creator);
             return res.status(201).json(newInstigate);
         } catch (error) {
             console.error('Error creating instigate:', error);


### PR DESCRIPTION
## Summary
- define badge rules in lib/badgeRules.js
- add badge helper to evaluate rules and update user badges
- trigger badge recalculation when debating, instigating, or voting

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68969c924498832d8921889a2870bac7