### PR TITLE
Track user instigate progress and badges

### DIFF
--- a/lib/updateBadges.js
+++ b/lib/updateBadges.js
@@ -15,8 +15,13 @@ export default function updateBadges(user, winRate, instigateCount) {
         }
     }
 
-    // instigateCount parameter is reserved for future badge rules
-    void instigateCount;
+    // Instigate count based badges
+    if (instigateCount >= 5 && !badges.has('5 Instigates')) {
+        badges.add('5 Instigates');
+    }
+    if (instigateCount >= 10 && !badges.has('10 Instigates')) {
+        badges.add('10 Instigates');
+    }
 
     return Array.from(badges);
 }

--- a/pages/api/user/debates.js
+++ b/pages/api/user/debates.js
@@ -89,6 +89,7 @@ export default async function handler(req, res) {
             totalDebates,
             wins,
             winRate,
+            instigateCount,
             points: userDoc?.points || 0,
             streak: userDoc?.streak || 0,
             badges: updatedBadges


### PR DESCRIPTION
## Summary
- Count user's instigated debates and return instigateCount in profile stats
- Award new badges for 5 and 10 instigated debates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896ae13a388832dbb330347b39b2f21