### PR TITLE
feat: add live vote updates

### DIFF
--- a/lib/deliberateEvents.js
+++ b/lib/deliberateEvents.js
@@ -1,0 +1,9 @@
+import { EventEmitter } from 'events';
+
+// Use a global variable to ensure a single shared emitter across reloads
+const emitter = global.deliberateEventsEmitter || new EventEmitter();
+if (!global.deliberateEventsEmitter) {
+  global.deliberateEventsEmitter = emitter;
+}
+
+export default emitter;

--- a/pages/api/deliberate.js
+++ b/pages/api/deliberate.js
@@ -5,6 +5,7 @@ import User from '../../models/User';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import updateBadges from '../../lib/badgeHelper';
+import emitter from '../../lib/deliberateEvents';
 
 export default async function handler(req, res) {
     try {
@@ -82,7 +83,14 @@ export default async function handler(req, res) {
                     message: `Your debate received a new ${vote} vote.`
                 });
             }
-            
+
+            // Emit vote update to connected clients
+            emitter.emit('vote', {
+                debateId: savedDeliberation._id.toString(),
+                votesRed: savedDeliberation.votesRed || 0,
+                votesBlue: savedDeliberation.votesBlue || 0
+            });
+
             // Return only the necessary data
             res.status(200).json({
                 _id: savedDeliberation._id,

--- a/pages/api/deliberate/live.js
+++ b/pages/api/deliberate/live.js
@@ -1,0 +1,28 @@
+import emitter from '../../../lib/deliberateEvents';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  // Send an initial comment to establish the stream
+  res.write(': connected\n\n');
+
+  const onVote = (data) => {
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  emitter.on('vote', onVote);
+
+  req.on('close', () => {
+    emitter.off('vote', onVote);
+    res.end();
+  });
+}

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -20,6 +20,30 @@ export default function DeliberatePage({ initialDebates }) {
     const [showVotes, setShowVotes] = useState(false);
     const [hoveringSide, setHoveringSide] = useState('');
 
+    // Subscribe to live vote updates
+    useEffect(() => {
+        const eventSource = new EventSource('/api/deliberate/live');
+
+        eventSource.onmessage = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                setDebates((prevDebates) =>
+                    prevDebates.map((debate) =>
+                        debate._id === data.debateId
+                            ? { ...debate, votesRed: data.votesRed, votesBlue: data.votesBlue }
+                            : debate
+                    )
+                );
+            } catch (err) {
+                console.error('Error parsing SSE data:', err);
+            }
+        };
+
+        return () => {
+            eventSource.close();
+        };
+    }, []);
+
 
     // If there were no initialDebates, fetch them client-side
     useEffect(() => {


### PR DESCRIPTION
## Summary
- broadcast deliberation vote updates through Server-Sent Events
- emit vote events on API updates and subscribe on client

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896bad18c68832d897f0cf9e06ec8ca