### PR TITLE
Enable voting on individual deliberation pages

### DIFF
--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -1,7 +1,70 @@
+import { useState, useEffect } from 'react';
 import { NextSeo } from 'next-seo';
 import NavBar from '../../components/NavBar';
 
 export default function DeliberateDetail({ deliberation }) {
+  const [votes, setVotes] = useState({
+    votesRed: deliberation?.votesRed || 0,
+    votesBlue: deliberation?.votesBlue || 0,
+  });
+
+  useEffect(() => {
+    if (deliberation) {
+      setVotes({
+        votesRed: deliberation.votesRed || 0,
+        votesBlue: deliberation.votesBlue || 0,
+      });
+    }
+  }, [deliberation]);
+
+  useEffect(() => {
+    const eventSource = new EventSource('/api/deliberate/live');
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.debateId === deliberation._id) {
+          setVotes({
+            votesRed: data.votesRed || 0,
+            votesBlue: data.votesBlue || 0,
+          });
+        }
+      } catch (err) {
+        console.error('Error parsing SSE data:', err);
+      }
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [deliberation._id]);
+
+  const handleVote = async (vote) => {
+    try {
+      const response = await fetch('/api/deliberate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ debateId: deliberation._id, vote }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.details || data.error || 'Failed to update votes');
+      }
+
+      setVotes({
+        votesRed: data.votesRed || 0,
+        votesBlue: data.votesBlue || 0,
+      });
+    } catch (error) {
+      console.error('Error voting:', error);
+      alert(error.message || 'Failed to submit vote. Please try again.');
+    }
+  };
+
   if (!deliberation) {
     return <div>Deliberation not found</div>;
   }
@@ -21,6 +84,42 @@ export default function DeliberateDetail({ deliberation }) {
       <NavBar />
       <h1 style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
       <p style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '10px',
+          marginTop: '20px',
+        }}
+      >
+        <button
+          onClick={() => handleVote('red')}
+          style={{
+            backgroundColor: '#FF4D4D',
+            color: 'white',
+            padding: '10px 20px',
+            border: 'none',
+            borderRadius: '5px',
+            cursor: 'pointer',
+          }}
+        >
+          Vote Red ({votes.votesRed})
+        </button>
+        <button
+          onClick={() => handleVote('blue')}
+          style={{
+            backgroundColor: '#4D94FF',
+            color: 'white',
+            padding: '10px 20px',
+            border: 'none',
+            borderRadius: '5px',
+            cursor: 'pointer',
+          }}
+        >
+          Vote Blue ({votes.votesBlue})
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replicate debate vote logic on `deliberates/[id]`
- show Red/Blue vote buttons and track counts
- subscribe to `/api/deliberate/live` for real-time updates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899785031cc832dacfe444c72ebe5b5