### PR TITLE
Fix stats API to show all debates on leaderboard

### DIFF
--- a/pages/api/stats.js
+++ b/pages/api/stats.js
@@ -8,22 +8,19 @@ export default async function handler(req, res) {
 
     const { sort } = req.query;
     try {
-        // 1. Fetch all deliberations with at least 10 total votes
-        let debates = await Deliberate.find({
-            $expr: { $gte: [{ $add: ["$votesRed", "$votesBlue"] }, 10] }
-        }).lean();
+        // 1. Fetch all deliberations
+        let debates = await Deliberate.find({}).lean();
 
         // 2. Sort them based on the "sort" param
         debates = sortDeliberates(debates, sort);
 
-        // 3. Calculate total votes across the site
-        const allDebates = await Deliberate.find({}).lean();
-        const totalVotes = allDebates.reduce(
+        // 3. Calculate total votes and total debates across the site
+        const totalVotes = debates.reduce(
             (sum, d) => sum + d.votesRed + d.votesBlue,
             0
         );
 
-        return res.status(200).json({ debates, totalVotes });
+        return res.status(200).json({ debates, totalVotes, totalDebates: debates.length });
     } catch (error) {
         console.error('Error fetching stats:', error);
         return res.status(500).json({ error: 'Something went wrong.' });


### PR DESCRIPTION
## Summary
- remove 10-vote threshold from stats API
- return total debates and votes for leaderboard

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c98cefac0832d9c1e5fd7b3ff82e4