### PR TITLE
Centralize NavBar rendering

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -1,6 +1,5 @@
 // pages/debate.js
 import { useState, useEffect } from 'react';
-import NavBar from '../components/NavBar';
 import { NextSeo } from 'next-seo';
 
 export default function DebatePage({ initialDebates }) {
@@ -265,7 +264,6 @@ export default function DebatePage({ initialDebates }) {
                 position: 'relative',
             }}
         >
-            <NavBar />
             <NextSeo
                 title="Debate - Bicker"
                 description="Join ongoing debates and share your stance."/>

--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -1,7 +1,6 @@
 import { NextSeo } from 'next-seo';
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import NavBar from '../../components/NavBar';
 
 export default function DebateDetail({ debate }) {
   if (!debate) {
@@ -28,7 +27,6 @@ export default function DebateDetail({ debate }) {
           description: debate.debateText,
         }}
       />
-      <NavBar />
       <h1 style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
       <p style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
       <div style={{ textAlign: 'center', marginTop: '10px' }}>

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -1,7 +1,6 @@
 // pages/deliberate/index.js
 import { useState, useEffect } from 'react';
 
-import NavBar from '../components/NavBar'; // If you have a NavBar; otherwise remove
 import { NextSeo } from 'next-seo';
 
 // Helper function to shuffle array
@@ -216,7 +215,6 @@ export default function DeliberatePage({ initialDebates }) {
                 position: 'relative'
             }}
         >
-            <NavBar />
             <NextSeo
                 title="Deliberate - Bicker"
                 description="Vote on debates and see how others feel."/>

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { NextSeo } from 'next-seo';
-import NavBar from '../../components/NavBar';
 
 export default function DeliberateDetail({ deliberation }) {
   const [votes, setVotes] = useState({
@@ -81,7 +80,6 @@ export default function DeliberateDetail({ deliberation }) {
           description: deliberation.debateText,
         }}
       />
-      <NavBar />
       <h1 style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
       <p style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
-import NavBar from '../components/NavBar';
 
 export default function Home() {
     const router = useRouter();
@@ -25,9 +24,6 @@ export default function Home() {
                 overflow: 'hidden',
             }}
         >
-            {/* Navbar */}
-            <NavBar />
-
             {/* Split Screen */}
             <div
                 style={{

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -1,6 +1,5 @@
 // pages/instigate/index.js
 import { useState, useEffect } from 'react';
-import NavBar from '../components/NavBar';
 
 export default function InstigatePage() {
     const [instigates, setInstigates] = useState([]);
@@ -61,8 +60,6 @@ export default function InstigatePage() {
                 alignItems: 'center',
             }}
         >
-            <NavBar />
-
             <h1 style={{ textAlign: 'center', color: '#ffffff', marginBottom: '20px' }}>
                 Instigate
             </h1>

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import NavBar from '../components/NavBar';
 
 export default function Leaderboard() {
   const [debates, setDebates] = useState([]);
@@ -41,7 +40,6 @@ export default function Leaderboard() {
 
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
-      <NavBar />
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
         <p style={{ textAlign: 'center', marginBottom: '20px' }}>

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useSession, signIn } from 'next-auth/react';
-import NavBar from '../components/NavBar';
 
 export default function MyStats() {
   const { data: session } = useSession();
@@ -50,7 +49,6 @@ export default function MyStats() {
   if (!session) {
     return (
       <div style={{ paddingTop: '60px', textAlign: 'center' }}>
-        <NavBar />
         <h2>Please sign in to view your stats.</h2>
         <button onClick={() => signIn('google')}>Sign In with Google</button>
       </div>
@@ -59,7 +57,6 @@ export default function MyStats() {
 
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
-      <NavBar />
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>


### PR DESCRIPTION
## Summary
- Render NavBar once in `_app.js` so it appears on every page
- Remove per-page NavBar imports and JSX from page components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689cea4793a4832d80b0ba94a09b9bab