### PR TITLE
feat: add global typography and web font

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,6 +5,12 @@ export default function Document() {
     <Html>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+          rel="stylesheet"
+        />
         <link rel="icon" href="/favicon_io/android-chrome-512x512.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon_io/android-chrome-192x192.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon_io/favicon-32x32.png" />
@@ -17,4 +23,5 @@ export default function Document() {
       </body>
     </Html>
   );
-} 
+}
+

--- a/pages/debate.js
+++ b/pages/debate.js
@@ -245,7 +245,7 @@ export default function DebatePage({ initialDebates }) {
                             backgroundColor: '#fff',
                         }}
                     >
-                        <p style={{ margin: 0, color: '#333' }}>{instigate.text}</p>
+                        <p className="text-base" style={{ margin: 0, color: '#333' }}>{instigate.text}</p>
                     </div>
                 ))}
             </div>
@@ -258,7 +258,6 @@ export default function DebatePage({ initialDebates }) {
                 flexDirection: isMobile ? 'column' : 'row',
                 minHeight: '100vh',
                 width: '100vw',
-                fontFamily: 'Arial, sans-serif',
                 overflowX: 'hidden',
                 overflowY: 'auto',
                 position: 'relative',
@@ -356,6 +355,7 @@ export default function DebatePage({ initialDebates }) {
                     }}
                 >
                     <p
+                        className="heading-1"
                         style={{
                             textAlign: 'center',
                             fontSize: isMobile ? '24px' : '40px',

--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -16,7 +16,7 @@ export default function DebateDetail({ debate }) {
   }, []);
 
   return (
-    <div style={{ paddingTop: '70px', fontFamily: 'Arial, sans-serif' }}>
+    <div style={{ paddingTop: '70px' }}>
       <NextSeo
         title={`Debate: ${debate.instigateText}`}
         description={debate.debateText}
@@ -27,8 +27,8 @@ export default function DebateDetail({ debate }) {
           description: debate.debateText,
         }}
       />
-      <h1 style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
-      <p style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
+      <h1 className="heading-1" style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
+      <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
         <Link href={`/deliberates/${debate._id}`}>Vote on this debate</Link>
       </div>

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -158,8 +158,8 @@ export default function DeliberatePage({ initialDebates }) {
     if (!currentDebate) {
         return (
             <div style={{ textAlign: 'center', marginTop: '50px' }}>
-                <h2>No debates available</h2>
-                <p>You've voted on all available debates! Check back later for new debates.</p>
+                <h2 className="heading-2">No debates available</h2>
+                <p className="text-base">You've voted on all available debates! Check back later for new debates.</p>
                 <button 
                     onClick={fetchDeliberations}
                     style={{
@@ -265,9 +265,8 @@ export default function DeliberatePage({ initialDebates }) {
                     
                 >
                     <p
+                        className="heading-3"
                         style={{
-                            fontWeight: 'bold',
-                            fontSize: '24px',
                             textAlign: 'center',
                             margin: 0,
                             whiteSpace: 'normal',
@@ -280,7 +279,7 @@ export default function DeliberatePage({ initialDebates }) {
                         {currentDebate.instigateText || 'Unknown Instigate'}
                     </p>
                     {showVotes && (
-                        <p style={{ fontSize: '18px', marginTop: '20px' }}>
+                        <p className="text-lg" style={{ marginTop: '20px' }}>
                             Votes: {currentDebate.votesRed || 0}
                         </p>
                     )}
@@ -306,9 +305,8 @@ export default function DeliberatePage({ initialDebates }) {
                     
                 >
                     <p
+                        className="heading-3"
                         style={{
-                            fontWeight: 'bold',
-                            fontSize: '24px',
                             textAlign: 'center',
                             margin: 0,
                             whiteSpace: 'normal',
@@ -321,7 +319,7 @@ export default function DeliberatePage({ initialDebates }) {
                         {currentDebate.debateText || 'Unknown Debate'}
                     </p>
                     {showVotes && (
-                        <p style={{ fontSize: '18px', marginTop: '20px' }}>
+                        <p className="text-lg" style={{ marginTop: '20px' }}>
                             Votes: {currentDebate.votesBlue || 0}
                         </p>
                     )}

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -69,7 +69,7 @@ export default function DeliberateDetail({ deliberation }) {
   }
 
   return (
-    <div style={{ paddingTop: '70px', fontFamily: 'Arial, sans-serif' }}>
+    <div style={{ paddingTop: '70px' }}>
       <NextSeo
         title={`Deliberation: ${deliberation.instigateText}`}
         description={deliberation.debateText}
@@ -80,8 +80,8 @@ export default function DeliberateDetail({ deliberation }) {
           description: deliberation.debateText,
         }}
       />
-      <h1 style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
-      <p style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
+      <h1 className="heading-1" style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
+      <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
 
       <div
         style={{

--- a/pages/index.js
+++ b/pages/index.js
@@ -51,6 +51,7 @@ export default function Home() {
                     onMouseLeave={(e) => (e.target.style.backgroundColor = '#FF4D4D')}
                 >
                     <h1
+                        className="heading-1"
                         style={{
                             fontSize: isMobile ? '28px' : '36px',
                             textAlign: 'center',
@@ -82,6 +83,7 @@ export default function Home() {
                     onMouseLeave={(e) => (e.target.style.backgroundColor = '#4D94FF')}
                 >
                     <h1
+                        className="heading-1"
                         style={{
                             fontSize: isMobile ? '28px' : '36px',
                             textAlign: 'center',

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -51,7 +51,6 @@ export default function InstigatePage() {
     return (
         <div
             style={{
-                fontFamily: 'Arial, sans-serif',
                 padding: '70px',
                 backgroundColor: '#ee4343',
                 minHeight: '100vh',
@@ -60,7 +59,7 @@ export default function InstigatePage() {
                 alignItems: 'center',
             }}
         >
-            <h1 style={{ textAlign: 'center', color: '#ffffff', marginBottom: '20px' }}>
+            <h1 className="heading-1" style={{ textAlign: 'center', color: '#ffffff', marginBottom: '20px' }}>
                 Instigate
             </h1>
 

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -41,8 +41,8 @@ export default function Leaderboard() {
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
-        <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
-        <p style={{ textAlign: 'center', marginBottom: '20px' }}>
+        <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
+        <p className="text-base" style={{ textAlign: 'center', marginBottom: '20px' }}>
           Total Debates: {totalDebates} | Total Votes: {totalVotes}
         </p>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
@@ -69,7 +69,7 @@ export default function Leaderboard() {
                   boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
                 }}
               >
-                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
                   {debate.instigateText}
                 </p>
               </div>
@@ -86,7 +86,7 @@ export default function Leaderboard() {
                   boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
                 }}
               >
-                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
                   {debate.debateText}
                 </p>
               </div>

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -49,7 +49,7 @@ export default function MyStats() {
   if (!session) {
     return (
       <div style={{ paddingTop: '60px', textAlign: 'center' }}>
-        <h2>Please sign in to view your stats.</h2>
+        <h2 className="heading-2">Please sign in to view your stats.</h2>
         <button onClick={() => signIn('google')}>Sign In with Google</button>
       </div>
     );
@@ -58,13 +58,13 @@ export default function MyStats() {
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
-        <h1 style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
+        <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <p style={{ margin: '4px 0' }}>Debates Participated: {totalDebates}</p>
-          <p style={{ margin: '4px 0' }}>Win Rate: {winRate}%</p>
-          <p style={{ margin: '4px 0' }}>Total Points: {points}</p>
-          <p style={{ margin: '4px 0' }}>Current Streak: {streak}</p>
-          <p style={{ margin: '4px 0' }}>Badges: {badges.length ? badges.join(', ') : 'None'}</p>
+          <p className="text-base" style={{ margin: '4px 0' }}>Debates Participated: {totalDebates}</p>
+          <p className="text-base" style={{ margin: '4px 0' }}>Win Rate: {winRate}%</p>
+          <p className="text-base" style={{ margin: '4px 0' }}>Total Points: {points}</p>
+          <p className="text-base" style={{ margin: '4px 0' }}>Current Streak: {streak}</p>
+          <p className="text-base" style={{ margin: '4px 0' }}>Badges: {badges.length ? badges.join(', ') : 'None'}</p>
         </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
@@ -78,12 +78,12 @@ export default function MyStats() {
           <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
               <div style={{ alignSelf: 'flex-start', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#FF4D4D', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopLeftRadius: '4px', marginLeft: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
-                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
                   {debate.instigateText}
                 </p>
               </div>
               <div style={{ alignSelf: 'flex-end', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#4D94FF', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopRightRadius: '4px', marginRight: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
-                <p style={{ margin: 0, fontSize: isMobile ? '16px' : '18px', lineHeight: '1.4' }}>
+                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
                   {debate.debateText}
                 </p>
               </div>
@@ -100,7 +100,7 @@ export default function MyStats() {
           </div>
         ))}
         {debates.length === 0 && (
-          <p style={{ textAlign: 'center' }}>You have not participated in any debates yet.</p>
+          <p className="text-base" style={{ textAlign: 'center' }}>You have not participated in any debates yet.</p>
         )}
         <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
           <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,58 @@
 /* styles/globals.css */
+
+:root {
+    --font-family-sans: 'Inter', sans-serif;
+    --font-size-sm: 0.875rem;
+    --font-size-base: 1rem;
+    --font-size-lg: 1.125rem;
+    --line-height-text: 1.6;
+    --font-size-h1: 2.5rem;
+    --line-height-h1: 1.2;
+    --font-size-h2: 2rem;
+    --line-height-h2: 1.3;
+    --font-size-h3: 1.5rem;
+    --line-height-h3: 1.4;
+}
+
 body {
     margin: 0;
     padding: 0;
-    font-family: Arial, sans-serif;
+    font-family: var(--font-family-sans);
     background-color: #f5f5f5;
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-text);
 }
+
+.heading-1 {
+    font-size: var(--font-size-h1);
+    line-height: var(--line-height-h1);
+    font-weight: 700;
+}
+
+.heading-2 {
+    font-size: var(--font-size-h2);
+    line-height: var(--line-height-h2);
+    font-weight: 600;
+}
+
+.heading-3 {
+    font-size: var(--font-size-h3);
+    line-height: var(--line-height-h3);
+    font-weight: 600;
+}
+
+.text-sm {
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-text);
+}
+
+.text-base {
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-text);
+}
+
+.text-lg {
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-text);
+}
+


### PR DESCRIPTION
## Summary
- add Inter via Google Fonts and apply sitewide
- define global typography scale and utility classes
- use new typography classes across headings and text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689ced923130832d9aacdec2a483a614