### PR TITLE
Replace sign-out with avatar and move sign-out to stats page

### DIFF
--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function Avatar({ src, alt, size = 44 }) {
+  const dimension = typeof size === 'number' ? size : 44;
+  const initials = alt ? alt.charAt(0).toUpperCase() : '?';
+  return (
+    <div
+      style={{
+        width: dimension,
+        height: dimension,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        backgroundColor: '#ccc',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 'bold',
+        color: '#fff'
+      }}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt={alt}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ) : (
+        <span>{initials}</span>
+      )}
+    </div>
+  );
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
+import Avatar from './Avatar';
 
 export default function NavBar() {
     const { data: session } = useSession();
@@ -130,12 +131,31 @@ export default function NavBar() {
                 </button>
             </Link>
 
+            {/* User avatar */}
+            {session && (
+                <Link href="/my-stats" passHref>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            right: isMobile ? '80px' : '20px',
+                            cursor: 'pointer'
+                        }}
+                    >
+                        <Avatar
+                            src={session.user?.image}
+                            alt={session.user?.name || 'User Avatar'}
+                            size={isMobile ? 54 : 44}
+                        />
+                    </div>
+                </Link>
+            )}
+
             {/* Notification bell */}
             {session && (
                 <div
                     style={{
                         position: 'absolute',
-                        right: isMobile ? '80px' : '20px'
+                        right: isMobile ? '140px' : '80px'
                     }}
                 >
                     <button
@@ -263,8 +283,7 @@ export default function NavBar() {
                         { label: 'Instigate', path: '/instigate' },
                         { label: 'Debate', path: '/debate' },
                         { label: 'Deliberate', path: '/deliberate' },
-                        { label: 'Leaderboard', path: '/leaderboard' },
-                        ...(session ? [{ label: 'My Stats', path: '/my-stats' }] : [])
+                        { label: 'Leaderboard', path: '/leaderboard' }
                     ].map(({ label, path }) => (
                         <Link key={label} href={path} passHref>
                             <button
@@ -276,16 +295,7 @@ export default function NavBar() {
                             </button>
                         </Link>
                     ))}
-                    {session ? (
-                        <button
-                            style={buttonStyle}
-                            onMouseEnter={handleMouseEnter}
-                            onMouseLeave={handleMouseLeave}
-                            onClick={() => signOut()}
-                        >
-                            Sign Out
-                        </button>
-                    ) : (
+                    {!session && (
                         <button
                             style={buttonStyle}
                             onMouseEnter={handleMouseEnter}
@@ -319,8 +329,7 @@ export default function NavBar() {
                 { label: 'Instigate', path: '/instigate' },
                 { label: 'Debate', path: '/debate' },
                 { label: 'Deliberate', path: '/deliberate' },
-                { label: 'Leaderboard', path: '/leaderboard' },
-                ...(session ? [{ label: 'My Stats', path: '/my-stats' }] : [])
+                { label: 'Leaderboard', path: '/leaderboard' }
             ].map(({ label, path }) => (
                 <Link key={label} href={path} passHref>
                     <button
@@ -337,20 +346,7 @@ export default function NavBar() {
                     </button>
                 </Link>
             ))}
-            {session ? (
-                <button
-                    style={{
-                        ...buttonStyle,
-                        width: '100%',
-                        margin: '5px 0',
-                        padding: '15px 20px',
-                        fontSize: '18px'
-                    }}
-                    onClick={() => { setIsMobileMenuOpen(false); signOut(); }}
-                >
-                    Sign Out
-                </button>
-            ) : (
+            {!session && (
                 <button
                     style={{
                         ...buttonStyle,

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSession, signIn } from 'next-auth/react';
+import { useSession, signIn, signOut } from 'next-auth/react';
 
 export default function MyStats() {
   const { data: session } = useSession();
@@ -60,6 +60,7 @@ export default function MyStats() {
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
+          <button onClick={() => signOut()} style={{ padding: '8px 16px', borderRadius: '4px', marginBottom: '10px' }}>Sign Out</button>
           <p className="text-base" style={{ margin: '4px 0' }}>Debates Participated: {totalDebates}</p>
           <p className="text-base" style={{ margin: '4px 0' }}>Win Rate: {winRate}%</p>
           <p className="text-base" style={{ margin: '4px 0' }}>Total Points: {points}</p>


### PR DESCRIPTION
## Summary
- swap sign-out button in navbar for avatar linking to My Stats
- add sign-out button to My Stats page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689cfe0e9488832d94805ba4c973e434