### PR TITLE
feat: use visual badges on stats page

### DIFF
--- a/components/ui/badge.js
+++ b/components/ui/badge.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const variantStyles = {
+  default: { backgroundColor: '#007bff', color: '#fff', border: '1px solid #007bff' },
+  secondary: { backgroundColor: '#6c757d', color: '#fff', border: '1px solid #6c757d' },
+  destructive: { backgroundColor: '#dc3545', color: '#fff', border: '1px solid #dc3545' },
+  outline: { backgroundColor: 'transparent', color: '#6c757d', border: '1px solid #6c757d' },
+};
+
+export function Badge({ variant = 'default', className = '', style = {}, children, ...props }) {
+  const baseStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    borderRadius: '9999px',
+    padding: '2px 8px',
+    fontSize: '0.75rem',
+    fontWeight: 500,
+  };
+  const combinedStyle = { ...baseStyle, ...(variantStyles[variant] || variantStyles.default), ...style };
+  return (
+    <span style={combinedStyle} className={className} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export default Badge;

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSession, signIn, signOut } from 'next-auth/react';
+import { Badge } from '../components/ui/badge';
 
 export default function MyStats() {
   const { data: session } = useSession();
@@ -65,7 +66,18 @@ export default function MyStats() {
           <p className="text-base" style={{ margin: '4px 0' }}>Win Rate: {winRate}%</p>
           <p className="text-base" style={{ margin: '4px 0' }}>Total Points: {points}</p>
           <p className="text-base" style={{ margin: '4px 0' }}>Current Streak: {streak}</p>
-          <p className="text-base" style={{ margin: '4px 0' }}>Badges: {badges.length ? badges.join(', ') : 'None'}</p>
+          <div className="text-base" style={{ margin: '4px 0' }}>
+            Badges:
+            {badges.length ? (
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '4px' }}>
+                {badges.map((badge) => (
+                  <Badge key={badge} variant="secondary">{badge}</Badge>
+                ))}
+              </div>
+            ) : (
+              ' None'
+            )}
+          </div>
         </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>


### PR DESCRIPTION
## Summary
- add shadcn-inspired Badge component
- render badges visually on My Stats page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689d02d12c60832d931f5816541a1fa1