### PR TITLE
Improve stats and leaderboard layout

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -42,9 +42,24 @@ export default function Leaderboard() {
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>Debate Leaderboard</h1>
-        <p className="text-base" style={{ textAlign: 'center', marginBottom: '20px' }}>
-          Total Debates: {totalDebates} | Total Votes: {totalVotes}
-        </p>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+            gap: '20px',
+            justifyItems: 'center',
+            marginBottom: '20px'
+          }}
+        >
+          <div>
+            <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{totalDebates}</p>
+            <p className="text-sm" style={{ margin: 0 }}>Total Debates</p>
+          </div>
+          <div>
+            <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{totalVotes}</p>
+            <p className="text-sm" style={{ margin: 0 }}>Total Votes</p>
+          </div>
+        </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
             <option value="newest">Newest First</option>

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -62,14 +62,36 @@ export default function MyStats() {
         <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <button onClick={() => signOut()} style={{ padding: '8px 16px', borderRadius: '4px', marginBottom: '10px' }}>Sign Out</button>
-          <p className="text-base" style={{ margin: '4px 0' }}>Debates Participated: {totalDebates}</p>
-          <p className="text-base" style={{ margin: '4px 0' }}>Win Rate: {winRate}%</p>
-          <p className="text-base" style={{ margin: '4px 0' }}>Total Points: {points}</p>
-          <p className="text-base" style={{ margin: '4px 0' }}>Current Streak: {streak}</p>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+              gap: '20px',
+              justifyItems: 'center',
+              marginBottom: '20px'
+            }}
+          >
+            <div>
+              <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{totalDebates}</p>
+              <p className="text-sm" style={{ margin: 0 }}>Debates</p>
+            </div>
+            <div>
+              <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{winRate}%</p>
+              <p className="text-sm" style={{ margin: 0 }}>Win Rate</p>
+            </div>
+            <div>
+              <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{points}</p>
+              <p className="text-sm" style={{ margin: 0 }}>Total Points</p>
+            </div>
+            <div>
+              <p style={{ fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>{streak}</p>
+              <p className="text-sm" style={{ margin: 0 }}>Current Streak</p>
+            </div>
+          </div>
           <div className="text-base" style={{ margin: '4px 0' }}>
             Badges:
             {badges.length ? (
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '4px' }}>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '4px', justifyContent: 'center' }}>
                 {badges.map((badge) => (
                   <Badge key={badge} variant="secondary">{badge}</Badge>
                 ))}


### PR DESCRIPTION
## Summary
- style My Stats page with responsive grid for debates, win rate, points, and streak
- show total debates and total votes in grid on leaderboard

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d062b978c832da05362d0a32dee18