### PR TITLE
feat: add account dropdown

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
-import { signIn, useSession } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 import Avatar from './Avatar';
 
 export default function NavBar() {
@@ -9,6 +9,7 @@ export default function NavBar() {
     const [isMobile, setIsMobile] = useState(false);
     const [notifications, setNotifications] = useState([]);
     const [showNotifications, setShowNotifications] = useState(false);
+    const [showUserMenu, setShowUserMenu] = useState(false);
 
     useEffect(() => {
         const checkMobile = () => {
@@ -133,13 +134,17 @@ export default function NavBar() {
 
             {/* User avatar */}
             {session && (
-                <Link href="/my-stats" passHref>
+                <div
+                    style={{
+                        position: 'absolute',
+                        right: isMobile ? '80px' : '20px'
+                    }}
+                    onMouseEnter={() => setShowUserMenu(true)}
+                    onMouseLeave={() => setShowUserMenu(false)}
+                >
                     <div
-                        style={{
-                            position: 'absolute',
-                            right: isMobile ? '80px' : '20px',
-                            cursor: 'pointer'
-                        }}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => setShowUserMenu(prev => !prev)}
                     >
                         <Avatar
                             src={session.user?.image}
@@ -147,7 +152,30 @@ export default function NavBar() {
                             size={isMobile ? 54 : 44}
                         />
                     </div>
-                </Link>
+                    {showUserMenu && (
+                        <div
+                            style={{
+                                position: 'absolute',
+                                top: isMobile ? '60px' : '60px',
+                                right: 0,
+                                backgroundColor: 'white',
+                                padding: '10px',
+                                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                zIndex: 1000
+                            }}
+                        >
+                            <Link href="/my-stats" passHref>
+                                <div style={{ padding: '5px 10px', cursor: 'pointer' }}>My Stats</div>
+                            </Link>
+                            <div
+                                style={{ padding: '5px 10px', cursor: 'pointer' }}
+                                onClick={() => signOut()}
+                            >
+                                Sign Out
+                            </div>
+                        </div>
+                    )}
+                </div>
             )}
 
             {/* Notification bell */}

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSession, signIn, signOut } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { Badge } from '../components/ui/badge';
 
 export default function MyStats() {
@@ -61,7 +61,6 @@ export default function MyStats() {
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
         <h1 className="heading-1" style={{ textAlign: 'center', marginBottom: '10px' }}>My Debates</h1>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <button onClick={() => signOut()} style={{ padding: '8px 16px', borderRadius: '4px', marginBottom: '10px' }}>Sign Out</button>
           <div
             style={{
               display: 'grid',


### PR DESCRIPTION
## Summary
- replace static profile link with dropdown menu containing My Stats and Sign Out
- remove redundant sign out button from My Stats page

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689d08c2e1a4832d86e7129afec9f681