### PR TITLE
Improve user dropdown styling and usability

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -137,7 +137,10 @@ export default function NavBar() {
                 <div
                     style={{
                         position: 'absolute',
-                        right: isMobile ? '80px' : '20px'
+                        right: isMobile ? '80px' : '20px',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-end'
                     }}
                     onMouseEnter={() => setShowUserMenu(true)}
                     onMouseLeave={() => setShowUserMenu(false)}
@@ -155,20 +158,28 @@ export default function NavBar() {
                     {showUserMenu && (
                         <div
                             style={{
-                                position: 'absolute',
-                                top: isMobile ? '60px' : '60px',
-                                right: 0,
+                                marginTop: '10px',
                                 backgroundColor: 'white',
-                                padding: '10px',
-                                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                padding: '10px 20px',
+                                boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+                                borderRadius: '8px',
+                                minWidth: '160px',
                                 zIndex: 1000
                             }}
                         >
                             <Link href="/my-stats" passHref>
-                                <div style={{ padding: '5px 10px', cursor: 'pointer' }}>My Stats</div>
+                                <div
+                                    style={{
+                                        padding: '8px 0',
+                                        cursor: 'pointer',
+                                        whiteSpace: 'nowrap'
+                                    }}
+                                >
+                                    My Stats
+                                </div>
                             </Link>
                             <div
-                                style={{ padding: '5px 10px', cursor: 'pointer' }}
+                                style={{ padding: '8px 0', cursor: 'pointer', whiteSpace: 'nowrap' }}
                                 onClick={() => signOut()}
                             >
                                 Sign Out


### PR DESCRIPTION
## Summary
- restyle user avatar dropdown with wider padding and rounded card
- keep dropdown open while cursor moves from avatar to menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Please define the MONGO_URI environment variable in .env.local)

------
https://chatgpt.com/codex/tasks/task_e_689d0ae34fc0832d99a7d9f83672e0c1