### PR TITLE
Animate mobile hamburger menu

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -280,39 +280,14 @@ export default function NavBar() {
 
             {/* Mobile menu button */}
             {isMobile && (
-                <button
+                <div
                     onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                    style={{
-                        ...buttonStyle,
-                        padding: '15px',
-                        width: '54px',
-                        height: '54px',
-                        borderRadius: '50%',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        position: 'absolute',
-                        right: '20px',
-                        backgroundColor: '#dc3545',
-                        boxShadow: '0 4px 0 #a71d2a'
-                    }}
+                    className={`hamburger-button ${isMobileMenuOpen ? 'open' : ''}`}
                 >
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="28"
-                        height="28"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    >
-                        <line x1="3" y1="12" x2="21" y2="12"></line>
-                        <line x1="3" y1="6" x2="21" y2="6"></line>
-                        <line x1="3" y1="18" x2="21" y2="18"></line>
-                    </svg>
-                </button>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </div>
             )}
 
             {/* Desktop menu */}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,3 +56,56 @@ body {
     line-height: var(--line-height-text);
 }
 
+/* Mobile hamburger button */
+.hamburger-button {
+    padding: 15px;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    right: 20px;
+    background-color: #dc3545;
+    box-shadow: 0 4px 0 #a71d2a;
+    cursor: pointer;
+}
+
+.hamburger-button span {
+    background: #fff;
+    border-radius: 10px;
+    height: 7px;
+    margin: 7px 0;
+    transition: 0.4s cubic-bezier(0.68, -0.6, 0.32, 1.6);
+}
+
+.hamburger-button span:nth-of-type(1) {
+    width: 50%;
+}
+
+.hamburger-button span:nth-of-type(2) {
+    width: 100%;
+}
+
+.hamburger-button span:nth-of-type(3) {
+    width: 75%;
+}
+
+.hamburger-button.open span:nth-of-type(1) {
+    transform-origin: bottom;
+    transform: rotateZ(45deg) translate(8px, 0);
+}
+
+.hamburger-button.open span:nth-of-type(2) {
+    transform-origin: top;
+    transform: rotateZ(-45deg);
+}
+
+.hamburger-button.open span:nth-of-type(3) {
+    transform-origin: bottom;
+    width: 50%;
+    transform: translate(30px, -11px) rotateZ(45deg);
+}
+


### PR DESCRIPTION
## Summary
- Replace static mobile menu icon with animated hamburger control
- Add global styles to transition hamburger into a close icon when menu is opened

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Please define the MONGO_URI environment variable)


------
https://chatgpt.com/codex/tasks/task_e_689d0ebab770832d949fe8b48255abf0