### PR TITLE
fix: adjust mobile hamburger

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -58,9 +58,9 @@ body {
 
 /* Mobile hamburger button */
 .hamburger-button {
-    padding: 15px;
-    width: 54px;
-    height: 54px;
+    padding: 10px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     display: flex;
     flex-direction: column;
@@ -76,36 +76,21 @@ body {
 .hamburger-button span {
     background: #fff;
     border-radius: 10px;
-    height: 7px;
-    margin: 7px 0;
+    height: 4px;
+    margin: 4px 0;
+    width: 60%;
     transition: 0.4s cubic-bezier(0.68, -0.6, 0.32, 1.6);
 }
 
-.hamburger-button span:nth-of-type(1) {
-    width: 50%;
-}
-
-.hamburger-button span:nth-of-type(2) {
-    width: 100%;
-}
-
-.hamburger-button span:nth-of-type(3) {
-    width: 75%;
-}
-
 .hamburger-button.open span:nth-of-type(1) {
-    transform-origin: bottom;
-    transform: rotateZ(45deg) translate(8px, 0);
+    transform: translateY(8px) rotate(45deg);
 }
 
 .hamburger-button.open span:nth-of-type(2) {
-    transform-origin: top;
-    transform: rotateZ(-45deg);
+    opacity: 0;
 }
 
 .hamburger-button.open span:nth-of-type(3) {
-    transform-origin: bottom;
-    width: 50%;
-    transform: translate(30px, -11px) rotateZ(45deg);
+    transform: translateY(-8px) rotate(-45deg);
 }
 


### PR DESCRIPTION
## Summary
- shrink mobile hamburger button to avoid covering the avatar
- simplify hamburger animation so bars morph into an "X" when open

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d3cc2d00c832dbd374872eb9db1af