### PR TITLE
refactor: replace selects with shadcn component

### DIFF
--- a/components/ui/select.js
+++ b/components/ui/select.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export function Select({ value, onValueChange, children, className = '', style = {} }) {
+  let options = null;
+  React.Children.forEach(children, child => {
+    if (child && child.type && child.type.displayName === 'SelectContent') {
+      options = child.props.children;
+    }
+  });
+  return (
+    <select
+      value={value}
+      onChange={(e) => onValueChange && onValueChange(e.target.value)}
+      className={className}
+      style={{ padding: '8px', borderRadius: '4px', ...style }}
+    >
+      {options}
+    </select>
+  );
+}
+Select.displayName = 'Select';
+
+export const SelectTrigger = ({ children }) => <>{children}</>;
+SelectTrigger.displayName = 'SelectTrigger';
+
+export const SelectValue = () => null;
+SelectValue.displayName = 'SelectValue';
+
+export const SelectContent = ({ children }) => <>{children}</>;
+SelectContent.displayName = 'SelectContent';
+
+export const SelectGroup = ({ children }) => <>{children}</>;
+SelectGroup.displayName = 'SelectGroup';
+
+export const SelectLabel = ({ children }) => <>{children}</>;
+SelectLabel.displayName = 'SelectLabel';
+
+export const SelectItem = ({ value, children }) => (
+  <option value={value}>{children}</option>
+);
+SelectItem.displayName = 'SelectItem';

--- a/pages/api/user/debates.js
+++ b/pages/api/user/debates.js
@@ -37,6 +37,10 @@ export default async function handler(req, res) {
             debates.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
         } else if (sort === 'newest') {
             debates.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+        } else if (sort === 'mostPopular') {
+            debates.sort(
+                (a, b) => (b.votesRed || 0) + (b.votesBlue || 0) - ((a.votesRed || 0) + (a.votesBlue || 0))
+            );
         } else if (sort === 'mostDivisive') {
             debates.sort((a, b) => {
                 const totalA = (a.votesRed || 0) + (a.votesBlue || 0);

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -1,4 +1,11 @@
 import { useState, useEffect } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../components/ui/select';
 
 export default function Leaderboard() {
   const [debates, setDebates] = useState([]);
@@ -61,12 +68,18 @@ export default function Leaderboard() {
           </div>
         </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
-            <option value="newest">Newest First</option>
-            <option value="oldest">Oldest First</option>
-            <option value="mostDivisive">Most Divisive</option>
-            <option value="mostDecisive">Most Decisive</option>
-          </select>
+          <Select value={sort} onValueChange={setSort}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="newest">Newest First</SelectItem>
+              <SelectItem value="oldest">Oldest First</SelectItem>
+              <SelectItem value="mostPopular">Most Popular</SelectItem>
+              <SelectItem value="mostDivisive">Most Divisive</SelectItem>
+              <SelectItem value="mostDecisive">Most Decisive</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         {debates.map((debate) => (
           <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,6 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import { Badge } from '../components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../components/ui/select';
 
 export default function MyStats() {
   const { data: session } = useSession();
@@ -101,12 +108,18 @@ export default function MyStats() {
           </div>
         </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <select value={sort} onChange={(e) => setSort(e.target.value)} style={{ padding: '8px', borderRadius: '4px' }}>
-            <option value="newest">Newest First</option>
-            <option value="oldest">Oldest First</option>
-            <option value="mostDivisive">Most Divisive</option>
-            <option value="mostDecisive">Most Decisive</option>
-          </select>
+          <Select value={sort} onValueChange={setSort}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="newest">Newest First</SelectItem>
+              <SelectItem value="oldest">Oldest First</SelectItem>
+              <SelectItem value="mostPopular">Most Popular</SelectItem>
+              <SelectItem value="mostDivisive">Most Divisive</SelectItem>
+              <SelectItem value="mostDecisive">Most Decisive</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         {debates.map((debate) => (
           <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>


### PR DESCRIPTION
## Summary
- replace native selects on leaderboard and stats pages with custom Select component
- allow sorting by total votes with new "Most Popular" option
- support mostPopular sorting in user debates API

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_689d4e1a0540832da74df4ea42db1550