### PR TITLE
feat: add shadcn pagination component

### DIFF
--- a/components/ui/pagination.js
+++ b/components/ui/pagination.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import Link from 'next/link'
+
+export function Pagination({ children, className = '', style = {}, ...props }) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      className={className}
+      style={{ display: 'flex', justifyContent: 'center', ...style }}
+      {...props}
+    >
+      {children}
+    </nav>
+  )
+}
+
+export function PaginationContent({ children, className = '', style = {}, ...props }) {
+  return (
+    <ul
+      className={className}
+      style={{ display: 'flex', listStyle: 'none', padding: 0, margin: 0, gap: '4px', ...style }}
+      {...props}
+    >
+      {children}
+    </ul>
+  )
+}
+
+export function PaginationItem({ children, className = '', style = {}, ...props }) {
+  return (
+    <li className={className} style={style} {...props}>
+      {children}
+    </li>
+  )
+}
+
+export function PaginationLink({ href, isActive, disabled, children, className = '', style = {}, ...props }) {
+  const baseStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '4px',
+    border: '1px solid #ccc',
+    padding: '0 8px',
+    height: '32px',
+    textDecoration: 'none',
+    color: '#000',
+    backgroundColor: isActive ? '#e5e7eb' : '#fff',
+    opacity: disabled ? 0.5 : 1,
+    pointerEvents: disabled ? 'none' : 'auto',
+  }
+
+  return (
+    <Link href={href} className={className} style={{ ...baseStyle, ...style }} {...props}>
+      {children}
+    </Link>
+  )
+}
+
+export function PaginationPrevious({ href, disabled, ...props }) {
+  return (
+    <PaginationLink href={href} disabled={disabled} {...props}>
+      Previous
+    </PaginationLink>
+  )
+}
+
+export function PaginationNext({ href, disabled, ...props }) {
+  return (
+    <PaginationLink href={href} disabled={disabled} {...props}>
+      Next
+    </PaginationLink>
+  )
+}
+
+export function PaginationEllipsis({ className = '', style = {}, ...props }) {
+  return (
+    <span
+      className={className}
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '32px', height: '32px', ...style }}
+      {...props}
+    >
+      ...
+    </span>
+  )
+}
+

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -6,6 +6,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '../components/ui/pagination';
 
 export default function Leaderboard() {
   const [debates, setDebates] = useState([]);
@@ -125,15 +133,44 @@ export default function Leaderboard() {
             </div>
           </div>
         ))}
-        <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
-          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
-            Prev
-          </button>
-          <span>Page {page} of {totalPages}</span>
-          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
-            Next
-          </button>
-        </div>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.max(1, p - 1));
+                }}
+                disabled={page === 1}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage(i + 1);
+                  }}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.min(totalPages, p + 1));
+                }}
+                disabled={page === totalPages}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       </div>
     </div>
   );

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -8,6 +8,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from '../components/ui/pagination';
 
 export default function MyStats() {
   const { data: session } = useSession();
@@ -149,15 +157,44 @@ export default function MyStats() {
         {debates.length === 0 && (
           <p className="text-base" style={{ textAlign: 'center' }}>You have not participated in any debates yet.</p>
         )}
-        <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
-          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
-            Prev
-          </button>
-          <span>Page {page} of {totalPages}</span>
-          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
-            Next
-          </button>
-        </div>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.max(1, p - 1));
+                }}
+                disabled={page === 1}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={page === i + 1}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage(i + 1);
+                  }}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.min(totalPages, p + 1));
+                }}
+                disabled={page === totalPages}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add shadcn-style pagination component using next/link
- replace manual pagination on leaderboard and my stats pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d51e64c08832d84dde98af8208cde