### PR TITLE
Add profile editing page with customizable avatar, bio, and badge

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -146,7 +146,7 @@ export default function NavBar() {
                     onMouseLeave={() => setShowUserMenu(false)}
                 >
                     <div
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px' }}
                         onClick={() => setShowUserMenu(prev => !prev)}
                     >
                         <Avatar
@@ -154,6 +154,9 @@ export default function NavBar() {
                             alt={session.user?.name || 'User Avatar'}
                             size={isMobile ? 54 : 44}
                         />
+                        {session.user?.selectedBadge && (
+                            <span style={{ fontSize: '12px' }}>{session.user.selectedBadge}</span>
+                        )}
                     </div>
                     {showUserMenu && (
                         <div
@@ -176,6 +179,17 @@ export default function NavBar() {
                                     }}
                                 >
                                     My Stats
+                                </div>
+                            </Link>
+                            <Link href="/profile" passHref>
+                                <div
+                                    style={{
+                                        padding: '8px 0',
+                                        cursor: 'pointer',
+                                        whiteSpace: 'nowrap'
+                                    }}
+                                >
+                                    Edit Profile
                                 </div>
                             </Link>
                             <div

--- a/models/User.js
+++ b/models/User.js
@@ -18,6 +18,18 @@ const UserSchema = new mongoose.Schema({
     badges: {
         type: [String],
         default: []
+    },
+    username: {
+        type: String
+    },
+    bio: {
+        type: String
+    },
+    avatar: {
+        type: String
+    },
+    selectedBadge: {
+        type: String
     }
 });
 

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -21,7 +21,9 @@ export const authOptions = {
                             email: user.email,
                             points: 0,
                             streak: 0,
-                            badges: []
+                            badges: [],
+                            username: user.name || '',
+                            avatar: user.image || ''
                         }
                     },
                     { upsert: true }
@@ -29,11 +31,23 @@ export const authOptions = {
             }
             return true;
         },
+        async session({ session }) {
+            await dbConnect();
+            if (session.user?.email) {
+                const dbUser = await User.findOne({ email: session.user.email });
+                if (dbUser) {
+                    session.user.username = dbUser.username || session.user.name;
+                    session.user.bio = dbUser.bio || '';
+                    session.user.image = dbUser.avatar || session.user.image;
+                    session.user.badges = dbUser.badges || [];
+                    session.user.selectedBadge = dbUser.selectedBadge || '';
+                }
+            }
+            return session;
+        },
         // The redirect callback is called anytime NextAuth needs to redirect
         async redirect({ url, baseUrl }) {
-            // If sign-in succeeded, send them to the homepage
             if (url.startsWith('/')) return `${baseUrl}${url}`;
-            // If you want to force them to always go to the homepage:
             return baseUrl;
         },
     },

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -1,0 +1,23 @@
+import { getSession } from 'next-auth/react';
+import dbConnect from '../../lib/dbConnect';
+import User from '../../models/User';
+
+export default async function handler(req, res) {
+  const session = await getSession({ req });
+  if (!session) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  await dbConnect();
+  const email = session.user.email;
+  if (req.method === 'GET') {
+    const user = await User.findOne({ email });
+    return res.json(user);
+  }
+  if (req.method === 'POST') {
+    const { username, bio, avatar, selectedBadge } = req.body;
+    const update = { username, bio, avatar, selectedBadge };
+    const user = await User.findOneAndUpdate({ email }, update, { new: true });
+    return res.json(user);
+  }
+  res.status(405).end();
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,66 @@
+import { useSession } from 'next-auth/react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Profile() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [form, setForm] = useState({ avatar: '', username: '', bio: '', selectedBadge: '' });
+  const [badges, setBadges] = useState([]);
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      fetch('/api/profile')
+        .then(res => res.json())
+        .then(data => {
+          setForm({
+            avatar: data.avatar || '',
+            username: data.username || '',
+            bio: data.bio || '',
+            selectedBadge: data.selectedBadge || ''
+          });
+          setBadges(data.badges || []);
+        });
+    }
+  }, [status]);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    router.reload();
+  };
+
+  if (status === 'loading') return <p>Loading...</p>;
+  if (status === 'unauthenticated') return <p>Please sign in to edit your profile.</p>;
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '600px', margin: '80px auto' }}>
+      <h1>Edit Profile</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <label>Avatar URL</label>
+        <input name="avatar" value={form.avatar} onChange={handleChange} />
+        <label>Username</label>
+        <input name="username" value={form.username} onChange={handleChange} />
+        <label>Bio</label>
+        <textarea name="bio" value={form.bio} onChange={handleChange} />
+        <label>Public Badge</label>
+        <select name="selectedBadge" value={form.selectedBadge} onChange={handleChange}>
+          <option value="">None</option>
+          {badges.map(b => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+        <button type="submit" style={{ marginTop: '10px' }}>Save</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow users to store custom username, bio, avatar, and chosen badge
- add profile editing page and API to update these fields
- display selected badge in navbar and link to edit profile

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d59fee6c4832d81d2ed03a237520a