### PR TITLE
Add profile customization fields and profile picture upload

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -132,7 +132,7 @@ export default function NavBar() {
                 </button>
             </Link>
 
-            {/* User avatar */}
+            {/* User profile picture */}
             {session && (
                 <div
                     style={{

--- a/models/User.js
+++ b/models/User.js
@@ -20,13 +20,16 @@ const UserSchema = new mongoose.Schema({
         default: []
     },
     username: {
-        type: String
+        type: String,
+        default: ''
     },
     bio: {
-        type: String
+        type: String,
+        default: ''
     },
-    avatar: {
-        type: String
+    profilePicture: {
+        type: String,
+        default: ''
     },
     selectedBadge: {
         type: String

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -23,7 +23,7 @@ export const authOptions = {
                             streak: 0,
                             badges: [],
                             username: user.name || '',
-                            avatar: user.image || ''
+                            profilePicture: user.image || ''
                         }
                     },
                     { upsert: true }
@@ -38,7 +38,7 @@ export const authOptions = {
                 if (dbUser) {
                     session.user.username = dbUser.username || session.user.name;
                     session.user.bio = dbUser.bio || '';
-                    session.user.image = dbUser.avatar || session.user.image;
+                    session.user.image = dbUser.profilePicture || session.user.image;
                     session.user.badges = dbUser.badges || [];
                     session.user.selectedBadge = dbUser.selectedBadge || '';
                 }

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -14,8 +14,8 @@ export default async function handler(req, res) {
     return res.json(user);
   }
   if (req.method === 'POST') {
-    const { username, bio, avatar, selectedBadge } = req.body;
-    const update = { username, bio, avatar, selectedBadge };
+    const { username, bio, profilePicture, selectedBadge } = req.body;
+    const update = { username, bio, profilePicture, selectedBadge };
     const user = await User.findOneAndUpdate(
       { email },
       { $set: update },

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 export default function Profile() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const [form, setForm] = useState({ avatar: '', username: '', bio: '', selectedBadge: '' });
+  const [form, setForm] = useState({ profilePicture: '', username: '', bio: '', selectedBadge: '' });
   const [badges, setBadges] = useState([]);
 
   useEffect(() => {
@@ -14,7 +14,7 @@ export default function Profile() {
         .then(res => res.json())
         .then(data => {
           setForm({
-            avatar: data.avatar || '',
+            profilePicture: data.profilePicture || '',
             username: data.username || '',
             bio: data.bio || '',
             selectedBadge: data.selectedBadge || ''
@@ -27,6 +27,14 @@ export default function Profile() {
   const handleChange = e => {
     const { name, value } = e.target;
     setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleFileChange = e => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setForm(prev => ({ ...prev, profilePicture: reader.result }));
+    reader.readAsDataURL(file);
   };
 
   const handleSubmit = async e => {
@@ -46,8 +54,15 @@ export default function Profile() {
     <div style={{ padding: '20px', maxWidth: '600px', margin: '80px auto' }}>
       <h1>Edit Profile</h1>
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        <label>Avatar URL</label>
-        <input name="avatar" value={form.avatar} onChange={handleChange} />
+        <label>Profile Picture</label>
+        <input type="file" accept="image/*" onChange={handleFileChange} />
+        {form.profilePicture && (
+          <img
+            src={form.profilePicture}
+            alt="Profile preview"
+            style={{ width: '100px', height: '100px', objectFit: 'cover' }}
+          />
+        )}
         <label>Username</label>
         <input name="username" value={form.username} onChange={handleChange} />
         <label>Bio</label>


### PR DESCRIPTION
## Summary
- allow users to set profile pictures, usernames, and bios in their account data
- support profile picture uploads with preview on the edit profile page
- ensure NextAuth session and API routes store and update the new profile information

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_689d5e31c4f4832d8b63bf1443b5e0b5