### PR TITLE
fix: refresh profile picture from profile data

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -10,6 +10,7 @@ export default function NavBar() {
     const [notifications, setNotifications] = useState([]);
     const [showNotifications, setShowNotifications] = useState(false);
     const [showUserMenu, setShowUserMenu] = useState(false);
+    const [profilePicture, setProfilePicture] = useState('');
 
     useEffect(() => {
         const checkMobile = () => {
@@ -27,6 +28,10 @@ export default function NavBar() {
             fetch('/api/notifications')
                 .then(res => res.json())
                 .then(data => setNotifications(data))
+                .catch(() => {});
+            fetch('/api/profile')
+                .then(res => res.json())
+                .then(data => setProfilePicture(data.profilePicture || ''))
                 .catch(() => {});
         }
     }, [session]);
@@ -150,7 +155,7 @@ export default function NavBar() {
                         onClick={() => setShowUserMenu(prev => !prev)}
                     >
                         <Avatar
-                            src={session.user?.image}
+                            src={profilePicture || session.user?.image}
                             alt={session.user?.name || 'User Avatar'}
                             size={isMobile ? 54 : 44}
                         />


### PR DESCRIPTION
## Summary
- fetch user profile in nav bar
- display profile API picture instead of stale session image

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689d60c3a268832d891473d5add1eba0