### PR TITLE
fix: ensure profile updates persist

### DIFF
--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -1,13 +1,14 @@
-import { getSession } from 'next-auth/react';
+import { getServerSession } from 'next-auth/next';
 import dbConnect from '../../lib/dbConnect';
 import User from '../../models/User';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req, res) {
-  const session = await getSession({ req });
+  await dbConnect();
+  const session = await getServerSession(req, res, authOptions);
   if (!session) {
     return res.status(401).json({ message: 'Unauthorized' });
   }
-  await dbConnect();
   const email = session.user.email;
   if (req.method === 'GET') {
     const user = await User.findOne({ email });


### PR DESCRIPTION
## Summary
- use `getServerSession` with `authOptions` in profile API for reliable authentication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_689d6807a358832d9819e4907e78d617