### PR TITLE
Remove navbar badge display

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -159,9 +159,6 @@ export default function NavBar() {
                             alt={session.user?.name || 'User Avatar'}
                             size={isMobile ? 54 : 44}
                         />
-                        {session.user?.selectedBadge && (
-                            <span style={{ fontSize: '12px' }}>{session.user.selectedBadge}</span>
-                        )}
                     </div>
                     {showUserMenu && (
                         <div


### PR DESCRIPTION
## Summary
- remove display of user's selected badge from the navbar avatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing MONGO_URI environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689df3f227a4832db7ce62bec8d8f78b