### PR TITLE
Add top players rankings to leaderboard

### DIFF
--- a/pages/api/topplayers.js
+++ b/pages/api/topplayers.js
@@ -1,0 +1,55 @@
+import dbConnect from '../../lib/dbConnect';
+import User from '../../models/User';
+import Deliberate from '../../models/Deliberate';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  try {
+    const users = await User.find({}).lean();
+    const debates = await Deliberate.find({}).lean();
+
+    const statsMap = {};
+    users.forEach(u => {
+      const key = u.email;
+      statsMap[key] = {
+        username: u.username || u.email,
+        wins: 0,
+        votes: 0,
+        debates: 0,
+      };
+    });
+
+    debates.forEach(d => {
+      const { instigatedBy, createdBy, votesRed = 0, votesBlue = 0 } = d;
+      if (statsMap[instigatedBy]) {
+        const stat = statsMap[instigatedBy];
+        stat.debates += 1;
+        stat.votes += votesRed;
+        if (votesRed > votesBlue) stat.wins += 1;
+      }
+      if (statsMap[createdBy]) {
+        const stat = statsMap[createdBy];
+        stat.debates += 1;
+        stat.votes += votesBlue;
+        if (votesBlue > votesRed) stat.wins += 1;
+      }
+    });
+
+    const statsArr = Object.values(statsMap).map(s => ({
+      username: s.username,
+      winRate: s.debates ? s.wins / s.debates : 0,
+      votes: s.votes,
+      debates: s.debates,
+    })).filter(s => s.debates > 0);
+
+    const highestWinRate = [...statsArr].sort((a, b) => b.winRate - a.winRate).slice(0, 10);
+    const mostVotes = [...statsArr].sort((a, b) => b.votes - a.votes).slice(0, 10);
+    const mostDebates = [...statsArr].sort((a, b) => b.debates - a.debates).slice(0, 10);
+    const lowestWinRate = [...statsArr].sort((a, b) => a.winRate - b.winRate).slice(0, 10);
+
+    res.status(200).json({ highestWinRate, mostVotes, mostDebates, lowestWinRate });
+  } catch (e) {
+    console.error('Error fetching top players:', e);
+    res.status(500).json({ error: 'Failed to fetch top players' });
+  }
+}

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -23,6 +23,8 @@ export default function Leaderboard() {
   const [totalDebates, setTotalDebates] = useState(0);
   const [totalVotes, setTotalVotes] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
+  const [showTopPlayers, setShowTopPlayers] = useState(false);
+  const [playerStats, setPlayerStats] = useState(null);
 
   useEffect(() => {
     const fetchDebates = async () => {
@@ -53,6 +55,20 @@ export default function Leaderboard() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  const toggleTopPlayers = async () => {
+    if (!showTopPlayers && !playerStats) {
+      try {
+        const res = await fetch('/api/topplayers');
+        if (!res.ok) throw new Error('Failed to fetch top players');
+        const data = await res.json();
+        setPlayerStats(data);
+      } catch (err) {
+        console.error('Error fetching top players:', err);
+      }
+    }
+    setShowTopPlayers(!showTopPlayers);
+  };
+
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#4D94FF', paddingTop: '60px' }}>
       <div style={{ maxWidth: '900px', margin: '0 auto', padding: '20px', color: 'white' }}>
@@ -75,6 +91,66 @@ export default function Leaderboard() {
             <p className="text-sm" style={{ margin: 0 }}>Total Votes</p>
           </div>
         </div>
+        <div style={{ textAlign: 'center', marginBottom: '20px' }}>
+          <button
+            onClick={toggleTopPlayers}
+            style={{
+              backgroundColor: 'white',
+              color: '#333',
+              padding: '8px 16px',
+              borderRadius: '8px',
+              fontWeight: 'bold'
+            }}
+          >
+            Top Players
+          </button>
+        </div>
+        {showTopPlayers && playerStats && (
+          <div style={{ backgroundColor: 'white', color: '#333', padding: '20px', borderRadius: '8px', marginBottom: '20px' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '20px' }}>
+              <div>
+                <h3 style={{ marginTop: 0 }}>Highest Win Rate</h3>
+                <ol>
+                  {playerStats.highestWinRate.map((p, i) => (
+                    <li key={p.username || i}>
+                      {p.username}: {(p.winRate * 100).toFixed(0)}%
+                    </li>
+                  ))}
+                </ol>
+              </div>
+              <div>
+                <h3 style={{ marginTop: 0 }}>Most Total Votes</h3>
+                <ol>
+                  {playerStats.mostVotes.map((p, i) => (
+                    <li key={p.username || i}>
+                      {p.username}: {p.votes}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+              <div>
+                <h3 style={{ marginTop: 0 }}>Most Debates Participated</h3>
+                <ol>
+                  {playerStats.mostDebates.map((p, i) => (
+                    <li key={p.username || i}>
+                      {p.username}: {p.debates}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+              <div>
+                <h3 style={{ marginTop: 0 }}>Biggest Loser</h3>
+                <ol>
+                  {playerStats.lowestWinRate.map((p, i) => (
+                    <li key={p.username || i}>
+                      {p.username}: {(p.winRate * 100).toFixed(0)}%
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+          </div>
+        )}
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
           <Select value={sort} onValueChange={setSort}>
             <SelectTrigger className="w-[180px]">


### PR DESCRIPTION
## Summary
- add API endpoint to compute player stats for win rate, votes, debates
- add Top Players button with ranking lists on leaderboard page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: MONGO_URI environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d4b06098832db318707d33b7c855