### PR TITLE
feat: allow users to customize color scheme

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -33,6 +33,10 @@ const UserSchema = new mongoose.Schema({
     },
     selectedBadge: {
         type: String
+    },
+    colorScheme: {
+        type: String,
+        default: 'light'
     }
 });
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,18 +1,39 @@
 import '../styles/globals.css';
-import { SessionProvider } from 'next-auth/react';
+import { SessionProvider, useSession } from 'next-auth/react';
+import { useEffect } from 'react';
 import NavBar from '../components/NavBar';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
-import { Analytics } from "@vercel/analytics/react"
+import { Analytics } from "@vercel/analytics/react";
 
+function ThemeProvider({ children }) {
+    const { status } = useSession();
+    useEffect(() => {
+        const applyScheme = scheme => {
+            document.body.classList.remove('light', 'dark', 'blue');
+            document.body.classList.add(scheme || 'light');
+        };
+        if (status === 'authenticated') {
+            fetch('/api/profile')
+                .then(res => res.json())
+                .then(data => applyScheme(data.colorScheme))
+                .catch(() => applyScheme('light'));
+        } else {
+            applyScheme('light');
+        }
+    }, [status]);
+    return children;
+}
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
     return (
         <SessionProvider session={session}>
-            <DefaultSeo {...SEO} />
-            <NavBar />
-            <Component {...pageProps} />
-            <Analytics/>
+            <ThemeProvider>
+                <DefaultSeo {...SEO} />
+                <NavBar />
+                <Component {...pageProps} />
+                <Analytics/>
+            </ThemeProvider>
         </SessionProvider>
     );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -17,7 +17,7 @@ export default function Document() {
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon_io/favicon-16x16.png" />
         {/* Add more links for different sizes and formats as needed */}
       </Head>
-      <body>
+      <body className="light">
         <Main />
         <NextScript />
       </body>

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -15,8 +15,8 @@ export default async function handler(req, res) {
     return res.json(user);
   }
   if (req.method === 'POST') {
-    const { username, bio, profilePicture, selectedBadge } = req.body;
-    const update = { username, bio, profilePicture, selectedBadge };
+    const { username, bio, profilePicture, selectedBadge, colorScheme } = req.body;
+    const update = { username, bio, profilePicture, selectedBadge, colorScheme };
     const user = await User.findOneAndUpdate(
       { email },
       { $set: update },

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 export default function Profile() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const [form, setForm] = useState({ profilePicture: '', username: '', bio: '', selectedBadge: '' });
+  const [form, setForm] = useState({ profilePicture: '', username: '', bio: '', selectedBadge: '', colorScheme: 'light' });
   const [badges, setBadges] = useState([]);
 
   useEffect(() => {
@@ -17,7 +17,8 @@ export default function Profile() {
             profilePicture: data.profilePicture || '',
             username: data.username || '',
             bio: data.bio || '',
-            selectedBadge: data.selectedBadge || ''
+            selectedBadge: data.selectedBadge || '',
+            colorScheme: data.colorScheme || 'light'
           });
           setBadges(data.badges || []);
         });
@@ -73,6 +74,12 @@ export default function Profile() {
           {badges.map(b => (
             <option key={b} value={b}>{b}</option>
           ))}
+        </select>
+        <label>Color Scheme</label>
+        <select name="colorScheme" value={form.colorScheme} onChange={handleChange}>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="blue">Blue</option>
         </select>
         <button type="submit" style={{ marginTop: '10px' }}>Save</button>
       </form>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,9 +18,23 @@ body {
     margin: 0;
     padding: 0;
     font-family: var(--font-family-sans);
-    background-color: #f5f5f5;
     font-size: var(--font-size-base);
     line-height: var(--line-height-text);
+}
+
+body.light {
+    background-color: #f5f5f5;
+    color: #1f1f1f;
+}
+
+body.dark {
+    background-color: #1f1f1f;
+    color: #f5f5f5;
+}
+
+body.blue {
+    background-color: #001f3f;
+    color: #ffffff;
 }
 
 .heading-1 {


### PR DESCRIPTION
## Summary
- let users choose a color scheme in profile settings
- store selected theme in user profile
- apply theme globally for signed-in users

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: MONGO_URI environment variable missing)


------
https://chatgpt.com/codex/tasks/task_e_68a4dae81010832d8a83938adc71d156