### PR TITLE
feat: add user profile pages

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import {
   Select,
   SelectContent,
@@ -113,7 +114,7 @@ export default function Leaderboard() {
                 <ol>
                   {playerStats.highestWinRate.map((p, i) => (
                     <li key={p.username || i}>
-                      {p.username}: {(p.winRate * 100).toFixed(0)}%
+                      <Link href={`/user/${encodeURIComponent(p.username)}`}>{p.username}</Link>: {(p.winRate * 100).toFixed(0)}%
                     </li>
                   ))}
                 </ol>
@@ -123,7 +124,7 @@ export default function Leaderboard() {
                 <ol>
                   {playerStats.mostVotes.map((p, i) => (
                     <li key={p.username || i}>
-                      {p.username}: {p.votes}
+                      <Link href={`/user/${encodeURIComponent(p.username)}`}>{p.username}</Link>: {p.votes}
                     </li>
                   ))}
                 </ol>
@@ -133,7 +134,7 @@ export default function Leaderboard() {
                 <ol>
                   {playerStats.mostDebates.map((p, i) => (
                     <li key={p.username || i}>
-                      {p.username}: {p.debates}
+                      <Link href={`/user/${encodeURIComponent(p.username)}`}>{p.username}</Link>: {p.debates}
                     </li>
                   ))}
                 </ol>
@@ -143,7 +144,7 @@ export default function Leaderboard() {
                 <ol>
                   {playerStats.lowestWinRate.map((p, i) => (
                     <li key={p.username || i}>
-                      {p.username}: {(p.winRate * 100).toFixed(0)}%
+                      <Link href={`/user/${encodeURIComponent(p.username)}`}>{p.username}</Link>: {(p.winRate * 100).toFixed(0)}%
                     </li>
                   ))}
                 </ol>

--- a/pages/user/[username].js
+++ b/pages/user/[username].js
@@ -1,0 +1,67 @@
+import dbConnect from '../../lib/dbConnect';
+import User from '../../models/User';
+import Deliberate from '../../models/Deliberate';
+
+export default function UserProfile({ user, debates }) {
+  if (!user) {
+    return <div style={{ padding: '20px', maxWidth: '800px', margin: '80px auto' }}>User not found.</div>;
+  }
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '800px', margin: '80px auto' }}>
+      {user.profilePicture && (
+        <img
+          src={user.profilePicture}
+          alt={`${user.username} profile picture`}
+          style={{ width: '150px', height: '150px', objectFit: 'cover', borderRadius: '50%' }}
+        />
+      )}
+      <h1>{user.username}</h1>
+      <h2 style={{ marginTop: '20px' }}>Debates Participated</h2>
+      {debates.length === 0 ? (
+        <p>No debates found.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {debates.map((d) => (
+            <li key={d._id} style={{ marginBottom: '15px', backgroundColor: 'white', padding: '10px', borderRadius: '8px' }}>
+              <p style={{ margin: 0, color: '#FF4D4D' }}>{d.instigateText}</p>
+              <p style={{ margin: 0, color: '#4D94FF' }}>{d.debateText}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export async function getServerSideProps({ params }) {
+  await dbConnect();
+  const { username } = params;
+  const identifier = decodeURIComponent(username);
+  const user = await User.findOne({ $or: [{ username: identifier }, { email: identifier }] }).lean();
+  if (!user) {
+    return { props: { user: null, debates: [] } };
+  }
+  const debatesDocs = await Deliberate.find({
+    $or: [
+      { createdBy: user.email },
+      { instigatedBy: user.email }
+    ]
+  }).sort({ createdAt: -1 }).lean();
+  const debates = debatesDocs.map((d) => ({
+    _id: d._id.toString(),
+    instigateText: d.instigateText,
+    debateText: d.debateText,
+    votesRed: d.votesRed || 0,
+    votesBlue: d.votesBlue || 0,
+  }));
+  return {
+    props: {
+      user: {
+        username: user.username || user.email,
+        profilePicture: user.profilePicture || '',
+      },
+      debates,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add dynamic user profile page showing avatar, username, and debates
- link leaderboard top players to user profiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5058253e4832d98e5958ea76b5200