### PR TITLE
Ensure debate links to existing deliberation

### DIFF
--- a/pages/api/debate.js
+++ b/pages/api/debate.js
@@ -75,8 +75,9 @@ export default async function handler(req, res) {
                 message: 'Your debate has been created.'
             });
 
-            // 3) Create a Deliberate doc with the same text
+            // 3) Create a Deliberate doc with the same text and reuse the debate's _id
             await Deliberate.create({
+                _id: newDebate._id, // ensure deliberation uses the same id as the debate
                 instigateText: instigate.text,
                 debateText: debateText.trim(),
                 createdBy: creator,


### PR DESCRIPTION
## Summary
- When creating a debate, reuse its ID for the associated deliberation document

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a5e8b653e0832d8f7d365304b695be