### PR TITLE
Redirect deliberation links to main page

### DIFF
--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -338,7 +338,7 @@ export async function getServerSideProps(context) {
     let initialDebates = [];
     try {
         initialDebates = await res.json();
-        
+
         // Better randomization using Fisher-Yates shuffle
         for (let i = initialDebates.length - 1; i > 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
@@ -347,9 +347,29 @@ export async function getServerSideProps(context) {
 
         // Add a random starting index
         const randomStartIndex = Math.floor(Math.random() * initialDebates.length);
-        initialDebates = [...initialDebates.slice(randomStartIndex), ...initialDebates.slice(0, randomStartIndex)];
+        initialDebates = [
+            ...initialDebates.slice(randomStartIndex),
+            ...initialDebates.slice(0, randomStartIndex),
+        ];
     } catch (error) {
         console.error('Error parsing JSON:', error);
+    }
+
+    // If a specific debate ID is provided, fetch it and place it first
+    const { id } = context.query;
+    if (id) {
+        try {
+            const specificRes = await fetch(`${baseUrl}/api/deliberate/${id}`);
+            if (specificRes.ok) {
+                const specificDebate = await specificRes.json();
+                initialDebates = [
+                    specificDebate,
+                    ...initialDebates.filter((debate) => debate._id !== specificDebate._id),
+                ];
+            }
+        } catch (error) {
+            console.error('Error fetching specific debate:', error);
+        }
     }
 
     return {

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -1,139 +1,17 @@
-import { useState, useEffect } from 'react';
-import { NextSeo } from 'next-seo';
+// Redirect individual deliberation routes to the main deliberate page
+// while preserving the debate ID via a query parameter.
 
-export default function DeliberateDetail({ deliberation }) {
-  const [votes, setVotes] = useState({
-    votesRed: deliberation?.votesRed || 0,
-    votesBlue: deliberation?.votesBlue || 0,
-  });
+export default function DeliberateRedirect() {
+  // This component never renders because getServerSideProps redirects first.
+  return null;
+}
 
-  useEffect(() => {
-    if (deliberation) {
-      setVotes({
-        votesRed: deliberation.votesRed || 0,
-        votesBlue: deliberation.votesBlue || 0,
-      });
-    }
-  }, [deliberation]);
-
-  useEffect(() => {
-    const eventSource = new EventSource('/api/deliberate/live');
-
-    eventSource.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        if (data.debateId === deliberation._id) {
-          setVotes({
-            votesRed: data.votesRed || 0,
-            votesBlue: data.votesBlue || 0,
-          });
-        }
-      } catch (err) {
-        console.error('Error parsing SSE data:', err);
-      }
-    };
-
-    return () => {
-      eventSource.close();
-    };
-  }, [deliberation._id]);
-
-  const handleVote = async (vote) => {
-    try {
-      const response = await fetch('/api/deliberate', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ debateId: deliberation._id, vote }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.details || data.error || 'Failed to update votes');
-      }
-
-      setVotes({
-        votesRed: data.votesRed || 0,
-        votesBlue: data.votesBlue || 0,
-      });
-    } catch (error) {
-      console.error('Error voting:', error);
-      alert(error.message || 'Failed to submit vote. Please try again.');
-    }
+export async function getServerSideProps({ params }) {
+  return {
+    redirect: {
+      destination: `/deliberate?id=${params.id}`,
+      permanent: false,
+    },
   };
-
-  if (!deliberation) {
-    return <div>Deliberation not found</div>;
-  }
-
-  return (
-    <div style={{ paddingTop: '70px' }}>
-      <NextSeo
-        title={`Deliberation: ${deliberation.instigateText}`}
-        description={deliberation.debateText}
-        canonical={`https://bicker.ca/deliberates/${deliberation._id}`}
-        openGraph={{
-          url: `https://bicker.ca/deliberates/${deliberation._id}`,
-          title: `Deliberation: ${deliberation.instigateText}`,
-          description: deliberation.debateText,
-        }}
-      />
-      <h1 className="heading-1" style={{ textAlign: 'center' }}>{deliberation.instigateText}</h1>
-      <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberation.debateText}</p>
-
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          gap: '10px',
-          marginTop: '20px',
-        }}
-      >
-        <button
-          onClick={() => handleVote('red')}
-          style={{
-            backgroundColor: '#FF4D4D',
-            color: 'white',
-            padding: '10px 20px',
-            border: 'none',
-            borderRadius: '5px',
-            cursor: 'pointer',
-          }}
-        >
-          Vote Red ({votes.votesRed})
-        </button>
-        <button
-          onClick={() => handleVote('blue')}
-          style={{
-            backgroundColor: '#4D94FF',
-            color: 'white',
-            padding: '10px 20px',
-            border: 'none',
-            borderRadius: '5px',
-            cursor: 'pointer',
-          }}
-        >
-          Vote Blue ({votes.votesBlue})
-        </button>
-      </div>
-    </div>
-  );
 }
 
-export async function getServerSideProps({ params, req }) {
-  const protocol = req.headers["x-forwarded-proto"] || "http";
-  const baseUrl = `${protocol}://${req.headers.host}`;
-  try {
-    const res = await fetch(`${baseUrl}/api/deliberate/${params.id}`);
-    if (!res.ok) {
-      return { notFound: true };
-    }
-    const deliberation = await res.json();
-    return { props: { deliberation } };
-  } catch (error) {
-    console.error('Failed to load deliberation:', error);
-    return { props: { deliberation: null } };
-  }
-}


### PR DESCRIPTION
## Summary
- redirect /deliberates/[id] to main deliberation page
- support loading a specific debate first when an id is provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f0040528832d8c60d018313696c5