### PR TITLE
Fix leaderboard links to original deliberate page

### DIFF
--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -30,7 +30,7 @@ export default function DebateDetail({ debate }) {
       <h1 className="heading-1" style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
       <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
-        <Link href={`/deliberates/${debate._id}`}>Vote on this debate</Link>
+        <Link href={`/deliberate?id=${debate._id}`}>Vote on this debate</Link>
       </div>
       <div style={{ textAlign: 'center', marginTop: '20px' }}>
         <button

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -20,9 +20,9 @@ export default function DeliberateDetail({ deliberate }) {
       <NextSeo
         title={`Deliberation: ${deliberate.instigateText}`}
         description={deliberate.debateText}
-        canonical={`https://bicker.ca/deliberates/${deliberate._id}`}
+        canonical={`https://bicker.ca/deliberate?id=${deliberate._id}`}
         openGraph={{
-          url: `https://bicker.ca/deliberates/${deliberate._id}`,
+          url: `https://bicker.ca/deliberate?id=${deliberate._id}`,
           title: `Deliberation: ${deliberate.instigateText}`,
           description: deliberate.debateText,
         }}

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -167,7 +167,7 @@ export default function Leaderboard() {
           </Select>
         </div>
         {debates.map((debate) => (
-          <Link key={debate._id} href={`/deliberates/${debate._id}`}>
+          <Link key={debate._id} href={`/deliberate?id=${debate._id}`}>
             <div
               style={{
                 backgroundColor: 'white',

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -19,7 +19,7 @@ function generateSiteMap(baseUrl, debates, deliberates) {
   const deliberateEntries = deliberates
     .map(
       (deliberate) =>
-        `\n  <url>\n    <loc>${baseUrl}/deliberates/${deliberate._id}</loc>\n    <lastmod>${deliberate.updatedAt.toISOString()}</lastmod>\n  </url>`
+        `\n  <url>\n    <loc>${baseUrl}/deliberate?id=${deliberate._id}</loc>\n    <lastmod>${deliberate.updatedAt.toISOString()}</lastmod>\n  </url>`
     )
     .join('');
 


### PR DESCRIPTION
## Summary
- Update leaderboard to link directly to the original deliberate page
- Update debate detail and sitemap entries to point to `deliberate?id=` routes
- Set canonical metadata on deliberation detail page to the original deliberate route

## Testing
- ⚠️ `npm test` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a61334545c832d892ce29163bd3788