### PR TITLE
Prevent profile clicks from casting votes on deliberate page

### DIFF
--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -291,6 +291,7 @@ export default function DeliberatePage({ initialDebates }) {
                                 textDecoration: 'none',
                                 fontSize: '0.875rem'
                             }}
+                            onClick={(e) => e.stopPropagation()}
                         >
                             {currentDebate.instigator.profilePicture && (
                                 <img
@@ -354,6 +355,7 @@ export default function DeliberatePage({ initialDebates }) {
                                 textDecoration: 'none',
                                 fontSize: '0.875rem'
                             }}
+                            onClick={(e) => e.stopPropagation()}
                         >
                             {currentDebate.creator.profilePicture && (
                                 <img


### PR DESCRIPTION
## Summary
- stop vote handler from firing when clicking debate participant profiles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62e011c60832d81e206fd4f987669