### PR TITLE
Persist last three notifications

### DIFF
--- a/pages/api/notifications.js
+++ b/pages/api/notifications.js
@@ -13,8 +13,9 @@ export default async function handler(req, res) {
     const userId = session.user.email;
 
     if (req.method === 'GET') {
-        const notifications = await Notification.find({ userId, read: false }).sort({ createdAt: -1 });
-        return res.status(200).json(notifications);
+        const notifications = await Notification.find({ userId }).sort({ createdAt: -1 }).limit(3);
+        const unreadCount = await Notification.countDocuments({ userId, read: false });
+        return res.status(200).json({ notifications, unreadCount });
     } else if (req.method === 'POST') {
         const { ids } = req.body;
         if (!ids || !Array.isArray(ids)) {


### PR DESCRIPTION
## Summary
- Return last three notifications and unread count from API
- Track unread count in NavBar and keep notifications after reading
- Show unread count badge while retaining recent notifications

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing MONGO_URI environment variable)


------
https://chatgpt.com/codex/tasks/task_e_68a6408081e8832d93ce2cce655e6560