### PR TITLE
Fix 500 error when following leaderboard debate links

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -167,7 +167,7 @@ export default function Leaderboard() {
           </Select>
         </div>
         {debates.map((debate) => (
-          <Link key={debate._id} href={`/deliberate?id=${debate._id}`}>
+          <Link key={debate._id} href={`/deliberates/${debate._id}`}>
             <div
               style={{
                 backgroundColor: 'white',


### PR DESCRIPTION
## Summary
- Fix leaderboard debate links to point to deliberation details route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6915c23b0832da862ddd409bd2578