### PR TITLE
Fix leaderboard debate links to existing deliberation pages

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -166,8 +166,8 @@ export default function Leaderboard() {
             </SelectContent>
           </Select>
         </div>
-        {debates.map((debate) => (
-          <Link key={debate._id} href={`/deliberates/${debate._id}`}>
+          {debates.map((debate) => (
+          <Link key={debate._id} href={`/deliberate?id=${debate._id}`}>
             <div
               style={{
                 backgroundColor: 'white',


### PR DESCRIPTION
## Summary
- Ensure leaderboard debates link to their existing deliberation pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a694cf2a6c832db4ce38f26f461efa