### PR TITLE
feat: add voice note option for debates

### DIFF
--- a/components/VoiceRecorder.js
+++ b/components/VoiceRecorder.js
@@ -1,0 +1,84 @@
+import { useState, useRef } from 'react';
+
+export default function VoiceRecorder({ onRecordingComplete }) {
+    const [isRecording, setIsRecording] = useState(false);
+    const [audioUrl, setAudioUrl] = useState('');
+    const mediaRecorderRef = useRef(null);
+    const chunksRef = useRef([]);
+
+    const startRecording = async () => {
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            const mediaRecorder = new MediaRecorder(stream);
+            mediaRecorderRef.current = mediaRecorder;
+            chunksRef.current = [];
+
+            mediaRecorder.ondataavailable = (e) => {
+                if (e.data.size > 0) {
+                    chunksRef.current.push(e.data);
+                }
+            };
+
+            mediaRecorder.onstop = () => {
+                const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+                const url = URL.createObjectURL(blob);
+                setAudioUrl(url);
+                const reader = new FileReader();
+                reader.onloadend = () => {
+                    const base64data = reader.result.split(',')[1];
+                    onRecordingComplete(base64data);
+                };
+                reader.readAsDataURL(blob);
+                stream.getTracks().forEach((track) => track.stop());
+            };
+
+            mediaRecorder.start();
+            setIsRecording(true);
+
+            setTimeout(() => {
+                if (mediaRecorder.state !== 'inactive') {
+                    mediaRecorder.stop();
+                    setIsRecording(false);
+                }
+            }, 20000); // 20 seconds limit
+        } catch (err) {
+            console.error('Error accessing microphone', err);
+        }
+    };
+
+    const stopRecording = () => {
+        if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+            mediaRecorderRef.current.stop();
+            setIsRecording(false);
+        }
+    };
+
+    const handleRecordClick = () => {
+        if (isRecording) {
+            stopRecording();
+        } else {
+            startRecording();
+        }
+    };
+
+    const clearRecording = () => {
+        setAudioUrl('');
+        onRecordingComplete('');
+    };
+
+    return (
+        <div style={{ textAlign: 'center', marginTop: '10px' }}>
+            {audioUrl && (
+                <div style={{ marginBottom: '10px' }}>
+                    <audio controls src={audioUrl}></audio>
+                    <button onClick={clearRecording} style={{ marginLeft: '10px' }}>
+                        Clear
+                    </button>
+                </div>
+            )}
+            <button onClick={handleRecordClick} style={{ padding: '8px 12px', cursor: 'pointer' }}>
+                {isRecording ? 'Stop Recording' : 'Record Voice Note'}
+            </button>
+        </div>
+    );
+}

--- a/models/Debate.js
+++ b/models/Debate.js
@@ -4,13 +4,17 @@ import mongoose from 'mongoose';
 const DebateSchema = new mongoose.Schema({
     instigateText: {
         type: String,
-        required: true,
         maxlength: 200,
+    },
+    instigateVoiceNote: {
+        type: String,
     },
     debateText: {
         type: String,
-        required: true,
         maxlength: 200,
+    },
+    debateVoiceNote: {
+        type: String,
     },
     createdBy: {
         type: String,

--- a/models/Deliberate.js
+++ b/models/Deliberate.js
@@ -4,13 +4,17 @@ import mongoose from 'mongoose';
 const DeliberateSchema = new mongoose.Schema({
     instigateText: {
         type: String,
-        required: true,
         maxlength: 200,
+    },
+    instigateVoiceNote: {
+        type: String,
     },
     debateText: {
         type: String,
-        required: true,
         maxlength: 200,
+    },
+    debateVoiceNote: {
+        type: String,
     },
     createdBy: {
         type: String,

--- a/models/Instigate.js
+++ b/models/Instigate.js
@@ -5,8 +5,10 @@ const InstigateSchema = new mongoose.Schema(
     {
         text: {
             type: String,
-            required: true,
             maxlength: 200,
+        },
+        voiceNote: {
+            type: String,
         },
         createdBy: {
             type: String,

--- a/pages/api/debate.js
+++ b/pages/api/debate.js
@@ -31,14 +31,14 @@ export default async function handler(req, res) {
             }
         }
 
-        const { instigateId, debateText } = req.body;
-        
+        const { instigateId, debateText, voiceNote } = req.body;
+
         // Validate input
-        if (!instigateId || !debateText) {
+        if (!instigateId || ((!debateText || debateText.trim().length === 0) && !voiceNote)) {
             return res.status(400).json({ error: 'Missing required fields' });
         }
 
-        if (debateText.length > 200) {
+        if (debateText && debateText.length > 200) {
             return res.status(400).json({ error: 'Debate text must be 200 characters or less' });
         }
 
@@ -56,7 +56,9 @@ export default async function handler(req, res) {
             // 2) Create the Debate
             const newDebate = await Debate.create({
                 instigateText: instigate.text,
-                debateText: debateText.trim(),
+                instigateVoiceNote: instigate.voiceNote,
+                debateText: debateText ? debateText.trim() : '',
+                debateVoiceNote: voiceNote,
                 createdBy: creator,
                 instigatedBy: instigator
             });
@@ -79,7 +81,9 @@ export default async function handler(req, res) {
             await Deliberate.create({
                 _id: newDebate._id, // ensure deliberation uses the same id as the debate
                 instigateText: instigate.text,
-                debateText: debateText.trim(),
+                instigateVoiceNote: instigate.voiceNote,
+                debateText: debateText ? debateText.trim() : '',
+                debateVoiceNote: voiceNote,
                 createdBy: creator,
                 instigatedBy: instigator,
                 votesRed: 0,

--- a/pages/api/instigate.js
+++ b/pages/api/instigate.js
@@ -8,16 +8,21 @@ export default async function handler(req, res) {
     await dbConnect();
 
     if (req.method === 'POST') {
-        const { text } = req.body;
+        const { text, voiceNote } = req.body;
         const session = await getServerSession(req, res, authOptions);
         const creator = session?.user?.email || 'anonymous';
-        if (!text || text.length > 200) {
+        if ((!text || text.trim().length === 0) && !voiceNote) {
             return res
                 .status(400)
-                .json({ error: 'Text is required and must be under 200 characters.' });
+                .json({ error: 'Text or voice note is required.' });
         }
-            try {
-            const newInstigate = await Instigate.create({ text, createdBy: creator });
+        if (text && text.length > 200) {
+            return res
+                .status(400)
+                .json({ error: 'Text must be under 200 characters.' });
+        }
+        try {
+            const newInstigate = await Instigate.create({ text, voiceNote, createdBy: creator });
             await updateBadges(creator);
             return res.status(201).json(newInstigate);
         } catch (error) {

--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -28,7 +28,17 @@ export default function DebateDetail({ debate }) {
         }}
       />
       <h1 className="heading-1" style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
+      {debate.instigateVoiceNote && (
+        <div style={{ textAlign: 'center', marginTop: '10px' }}>
+          <audio controls src={`data:audio/webm;base64,${debate.instigateVoiceNote}`} />
+        </div>
+      )}
       <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
+      {debate.debateVoiceNote && (
+        <div style={{ textAlign: 'center', marginTop: '10px' }}>
+          <audio controls src={`data:audio/webm;base64,${debate.debateVoiceNote}`} />
+        </div>
+      )}
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
         <Link href={`/deliberate?id=${debate._id}`}>Vote on this debate</Link>
       </div>

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -279,6 +279,12 @@ export default function DeliberatePage({ initialDebates }) {
                     >
                         {currentDebate.instigateText || 'Unknown Instigate'}
                     </p>
+                    {currentDebate.instigateVoiceNote && (
+                        <audio
+                            controls
+                            src={`data:audio/webm;base64,${currentDebate.instigateVoiceNote}`}
+                        />
+                    )}
                     {currentDebate.instigator && (
                         <Link
                             href={`/user/${encodeURIComponent(currentDebate.instigator.username)}`}
@@ -343,6 +349,12 @@ export default function DeliberatePage({ initialDebates }) {
                     >
                         {currentDebate.debateText || 'Unknown Debate'}
                     </p>
+                    {currentDebate.debateVoiceNote && (
+                        <audio
+                            controls
+                            src={`data:audio/webm;base64,${currentDebate.debateVoiceNote}`}
+                        />
+                    )}
                     {currentDebate.creator && (
                         <Link
                             href={`/user/${encodeURIComponent(currentDebate.creator.username)}`}

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -28,7 +28,17 @@ export default function DeliberateDetail({ deliberate }) {
         }}
       />
       <h1 className="heading-1" style={{ textAlign: 'center' }}>{deliberate.instigateText}</h1>
+      {deliberate.instigateVoiceNote && (
+        <div style={{ textAlign: 'center', marginTop: '10px' }}>
+          <audio controls src={`data:audio/webm;base64,${deliberate.instigateVoiceNote}`} />
+        </div>
+      )}
       <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberate.debateText}</p>
+      {deliberate.debateVoiceNote && (
+        <div style={{ textAlign: 'center', marginTop: '10px' }}>
+          <audio controls src={`data:audio/webm;base64,${deliberate.debateVoiceNote}`} />
+        </div>
+      )}
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
         <Link href={`/deliberate?id=${deliberate._id}`}>Vote on this debate</Link>
       </div>

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -1,9 +1,13 @@
 // pages/instigate/index.js
 import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import VoiceRecorder from '../components/VoiceRecorder';
 
 export default function InstigatePage() {
     const [instigates, setInstigates] = useState([]);
     const [newInstigate, setNewInstigate] = useState('');
+    const [voiceNote, setVoiceNote] = useState('');
+    const { data: session } = useSession();
 
     // Disable scrolling on mount
     useEffect(() => {
@@ -34,13 +38,19 @@ export default function InstigatePage() {
 
     const submitInstigate = async () => {
 
+        if (!newInstigate.trim() && !voiceNote) {
+            alert('Please provide text or a voice note.');
+            return;
+        }
+
         try {
             await fetch('/api/instigate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ text: newInstigate }),
+                body: JSON.stringify({ text: newInstigate.trim(), voiceNote }),
             });
             setNewInstigate('');
+            setVoiceNote('');
             fetchInstigates();
         } catch (error) {
             console.error('Error submitting instigate:', error);
@@ -103,6 +113,9 @@ export default function InstigatePage() {
                         {newInstigate.length}/200
                     </div>
                 </div>
+                {session && (
+                    <VoiceRecorder onRecordingComplete={setVoiceNote} />
+                )}
                 <button
                     className="submit-topic-button"
                     onClick={submitInstigate}


### PR DESCRIPTION
## Summary
- allow instigating and debating with optional 20 second voice notes
- store voice note data in Instigate, Debate, and Deliberate models
- expose voice notes in API and UI for creation and viewing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6981b8a40832d89c1355246909292