### PR TITLE
feat: add content reporting system

### DIFF
--- a/models/Report.js
+++ b/models/Report.js
@@ -1,0 +1,12 @@
+// models/Report.js
+import mongoose from 'mongoose';
+
+const ReportSchema = new mongoose.Schema({
+    targetId: { type: String, required: true },
+    targetType: { type: String, required: true },
+    reporter: { type: String, required: true },
+    reason: { type: String, required: true },
+    status: { type: String, enum: ['pending', 'resolved'], default: 'pending' }
+}, { timestamps: true });
+
+export default mongoose.models.Report || mongoose.model('Report', ReportSchema);

--- a/pages/admin/reports.js
+++ b/pages/admin/reports.js
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import dbConnect from '../../lib/dbConnect';
+import Report from '../../models/Report';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../api/auth/[...nextauth]';
+
+export default function ReportsAdmin({ reports: initialReports }) {
+  const [reports, setReports] = useState(initialReports);
+
+  const resolveReport = async (id) => {
+    const res = await fetch('/api/report', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, status: 'resolved' })
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      setReports(reports.map(r => r._id === id ? updated : r));
+    }
+  };
+
+  return (
+    <div style={{ paddingTop: '70px', maxWidth: '800px', margin: '0 auto' }}>
+      <h1 className="heading-1">Reports</h1>
+      {reports.length === 0 ? (
+        <p>No reports</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {reports.map(r => (
+            <li key={r._id} style={{ borderBottom: '1px solid #ccc', marginBottom: '15px', paddingBottom: '10px' }}>
+              <p><strong>Target:</strong> {r.targetType} {r.targetId}</p>
+              <p><strong>Reporter:</strong> {r.reporter}</p>
+              <p><strong>Reason:</strong> {r.reason}</p>
+              <p><strong>Status:</strong> {r.status}</p>
+              {r.status !== 'resolved' && (
+                <button onClick={() => resolveReport(r._id)}>Resolve</button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  const admins = (process.env.ADMIN_EMAILS || '').split(',').map(a => a.trim());
+  if (!session || !admins.includes(session.user.email)) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+  await dbConnect();
+  const reports = await Report.find({}).sort({ createdAt: -1 }).lean();
+  return {
+    props: {
+      reports: reports.map(r => ({
+        _id: r._id.toString(),
+        targetId: r.targetId,
+        targetType: r.targetType,
+        reporter: r.reporter,
+        reason: r.reason,
+        status: r.status,
+      })),
+    },
+  };
+}

--- a/pages/api/report.js
+++ b/pages/api/report.js
@@ -1,0 +1,51 @@
+import dbConnect from '../../lib/dbConnect';
+import Report from '../../models/Report';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+
+function isAdmin(email) {
+    const admins = (process.env.ADMIN_EMAILS || '').split(',').map(a => a.trim());
+    return email && admins.includes(email);
+}
+
+export default async function handler(req, res) {
+    await dbConnect();
+    const session = await getServerSession(req, res, authOptions);
+
+    if (req.method === 'POST') {
+        if (!session) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
+        const { targetId, targetType, reason } = req.body;
+        if (!targetId || !targetType || !reason) {
+            return res.status(400).json({ error: 'Missing required fields' });
+        }
+        const report = await Report.create({
+            targetId,
+            targetType,
+            reporter: session.user.email,
+            reason,
+            status: 'pending'
+        });
+        return res.status(201).json(report);
+    } else if (req.method === 'GET') {
+        if (!session || !isAdmin(session.user.email)) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+        const reports = await Report.find({}).sort({ createdAt: -1 });
+        return res.status(200).json(reports);
+    } else if (req.method === 'PUT') {
+        if (!session || !isAdmin(session.user.email)) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+        const { id, status } = req.body;
+        if (!id || !status) {
+            return res.status(400).json({ error: 'Missing required fields' });
+        }
+        const updated = await Report.findByIdAndUpdate(id, { status }, { new: true });
+        return res.status(200).json(updated);
+    } else {
+        res.setHeader('Allow', ['POST', 'GET', 'PUT']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+}

--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -15,6 +15,22 @@ export default function DebateDetail({ debate }) {
     }
   }, []);
 
+  const handleReport = async () => {
+    const reason = prompt('Why are you reporting this debate?');
+    if (!reason) return;
+    const res = await fetch('/api/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetId: debate._id, targetType: 'debate', reason })
+    });
+    if (res.ok) {
+      alert('Report submitted');
+    } else {
+      const data = await res.json();
+      alert(data.error || 'Failed to submit report');
+    }
+  };
+
   return (
     <div style={{ paddingTop: '70px' }}>
       <NextSeo
@@ -54,6 +70,9 @@ export default function DebateDetail({ debate }) {
         >
           Share on Reddit
         </a>
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <button onClick={handleReport}>Report</button>
       </div>
     </div>
   );

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -15,6 +15,22 @@ export default function DeliberateDetail({ deliberate }) {
     }
   }, []);
 
+  const handleReport = async () => {
+    const reason = prompt('Why are you reporting this deliberation?');
+    if (!reason) return;
+    const res = await fetch('/api/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetId: deliberate._id, targetType: 'deliberate', reason })
+    });
+    if (res.ok) {
+      alert('Report submitted');
+    } else {
+      const data = await res.json();
+      alert(data.error || 'Failed to submit report');
+    }
+  };
+
   return (
     <div style={{ paddingTop: '70px' }}>
       <NextSeo
@@ -54,6 +70,9 @@ export default function DeliberateDetail({ deliberate }) {
         >
           Share on Reddit
         </a>
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <button onClick={handleReport}>Report</button>
       </div>
       <div style={{ textAlign: 'center', marginTop: '20px' }}>
         <p className="text-base">Red: {deliberate.votesRed || 0} | Blue: {deliberate.votesBlue || 0}</p>


### PR DESCRIPTION
## Summary
- add mongoose Report model
- expose API endpoints to submit and manage reports
- allow users to report debates or deliberations
- create admin panel to review and resolve reports

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a62e0e94832d8afe5cb0f375abf1