### PR TITLE
Fix deliberate share URLs

### DIFF
--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -36,9 +36,9 @@ export default function DeliberateDetail({ deliberate }) {
       <NextSeo
         title={`Deliberation: ${deliberate.instigateText}`}
         description={deliberate.debateText}
-        canonical={`https://bicker.ca/deliberate?id=${deliberate._id}`}
+        canonical={`https://bicker.ca/deliberates/${deliberate._id}`}
         openGraph={{
-          url: `https://bicker.ca/deliberate?id=${deliberate._id}`,
+          url: `https://bicker.ca/deliberates/${deliberate._id}`,
           title: `Deliberation: ${deliberate.instigateText}`,
           description: deliberate.debateText,
         }}

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -19,7 +19,7 @@ function generateSiteMap(baseUrl, debates, deliberates) {
   const deliberateEntries = deliberates
     .map(
       (deliberate) =>
-        `\n  <url>\n    <loc>${baseUrl}/deliberate?id=${deliberate._id}</loc>\n    <lastmod>${deliberate.updatedAt.toISOString()}</lastmod>\n  </url>`
+        `\n  <url>\n    <loc>${baseUrl}/deliberates/${deliberate._id}</loc>\n    <lastmod>${deliberate.updatedAt.toISOString()}</lastmod>\n  </url>`
     )
     .join('');
 


### PR DESCRIPTION
## Summary
- Use `/deliberates/[id]` URLs for canonical and OpenGraph on deliberation pages so shared links point to the intended page
- Update sitemap entries to reference `/deliberates/[id]`

## Testing
- `npm test` *(fails: Missing script "test" for npm)*

------
https://chatgpt.com/codex/tasks/task_e_68a8859bed40832d8431be333cfb3ada