### PR TITLE
Fix deliberate navigation to stylized page

### DIFF
--- a/pages/debates/[id].js
+++ b/pages/debates/[id].js
@@ -46,7 +46,9 @@ export default function DebateDetail({ debate }) {
       <h1 className="heading-1" style={{ textAlign: 'center' }}>{debate.instigateText}</h1>
       <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{debate.debateText}</p>
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
-        <Link href={`/deliberate?id=${debate._id}`}>Vote on this debate</Link>
+        <Link href={{ pathname: '/deliberate', query: { id: debate._id } }}>
+          Vote on this debate
+        </Link>
       </div>
       <div style={{ textAlign: 'center', marginTop: '20px' }}>
         <button

--- a/pages/deliberates/[id].js
+++ b/pages/deliberates/[id].js
@@ -46,7 +46,9 @@ export default function DeliberateDetail({ deliberate }) {
       <h1 className="heading-1" style={{ textAlign: 'center' }}>{deliberate.instigateText}</h1>
       <p className="text-base" style={{ maxWidth: '600px', margin: '20px auto' }}>{deliberate.debateText}</p>
       <div style={{ textAlign: 'center', marginTop: '10px' }}>
-        <Link href={`/deliberate?id=${deliberate._id}`}>Vote on this debate</Link>
+        <Link href={{ pathname: '/deliberate', query: { id: deliberate._id } }}>
+          Vote on this debate
+        </Link>
       </div>
       <div style={{ textAlign: 'center', marginTop: '20px' }}>
         <button

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -189,7 +189,7 @@ export default function Leaderboard() {
         {debates.map((debate) => (
           <Link
             key={debate._id}
-            href={`/deliberate?id=${debate._id}`}
+            href={{ pathname: '/deliberate', query: { id: debate._id } }}
             style={{ textDecoration: 'none', color: 'inherit' }}
           >
             <div


### PR DESCRIPTION
## Summary
- Ensure debate links navigate to `/deliberate` with query parameter for stylized layout
- Apply same navigation fix to deliberation detail and leaderboard pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a887af0304832db18a5b1be14c3c73