### PR TITLE
Fix share button link to deliberate page

### DIFF
--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -134,7 +134,7 @@ export default function DeliberatePage({ initialDebates }) {
     const currentDebate = debates[currentDebateIndex];
 
     const handleShare = () => {
-        const url = `${window.location.origin}/deliberates/${currentDebate._id}`;
+        const url = `${window.location.origin}/deliberate?id=${currentDebate._id}`;
         if (navigator.share) {
             navigator.share({ title: 'Deliberation', url });
         } else {


### PR DESCRIPTION
## Summary
- Update deliberate page share handler to copy link to new `/deliberate?id=` route.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a88c0b8f28832d9cdb1a56051a0e04