### PR TITLE
feat: update first debate badge

### DIFF
--- a/lib/badgeImages.js
+++ b/lib/badgeImages.js
@@ -1,0 +1,5 @@
+const badgeImages = {
+  'First Debate': '/badges/first-debate.svg'
+};
+
+export default badgeImages;

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import { Badge } from '../components/ui/badge';
+import badgeImages from '../lib/badgeImages';
 import {
   Select,
   SelectContent,
@@ -106,9 +107,14 @@ export default function MyStats() {
             Badges:
             {badges.length ? (
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '4px', justifyContent: 'center' }}>
-                {badges.map((badge) => (
-                  <Badge key={badge} variant="secondary">{badge}</Badge>
-                ))}
+                {badges.map((badge) => {
+                  const image = badgeImages[badge];
+                  return (
+                    <Badge key={badge} variant="secondary" style={image ? { padding: '2px' } : {}}>
+                      {image ? <img src={image} alt={badge} style={{ width: '16px', height: '16px' }} /> : badge}
+                    </Badge>
+                  );
+                })}
               </div>
             ) : (
               ' None'

--- a/pages/user/[username].js
+++ b/pages/user/[username].js
@@ -3,6 +3,7 @@ import dbConnect from '../../lib/dbConnect';
 import User from '../../models/User';
 import Deliberate from '../../models/Deliberate';
 import { Badge } from '../../components/ui/badge';
+import badgeImages from '../../lib/badgeImages';
 import {
   Select,
   SelectContent,
@@ -65,9 +66,14 @@ export default function UserProfile({ user, debates }) {
               <div className="text-base" style={{ marginTop: '8px' }}>
                 Badges:
                 <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '4px' }}>
-                  {user.badges.map((badge) => (
-                    <Badge key={badge} variant="secondary">{badge}</Badge>
-                  ))}
+                  {user.badges.map((badge) => {
+                    const image = badgeImages[badge];
+                    return (
+                      <Badge key={badge} variant="secondary" style={image ? { padding: '2px' } : {}}>
+                        {image ? <img src={image} alt={badge} style={{ width: '16px', height: '16px' }} /> : badge}
+                      </Badge>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/public/badges/first-debate.svg
+++ b/public/badges/first-debate.svg
@@ -1,0 +1,20 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="60%" stop-color="#FFE066"/>
+      <stop offset="100%" stop-color="#000000"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" fill="#000000"/>
+  <circle cx="256" cy="256" r="220" fill="url(#glow)"/>
+  <circle cx="256" cy="256" r="170" fill="#FFE5AD"/>
+  <circle cx="206" cy="240" r="30" fill="#333333"/>
+  <circle cx="306" cy="240" r="30" fill="#333333"/>
+  <circle cx="206" cy="280" r="20" fill="#FFB3B3"/>
+  <circle cx="306" cy="280" r="20" fill="#FFB3B3"/>
+  <g>
+    <circle cx="256" cy="320" r="70" fill="#4CAF50"/>
+    <circle cx="256" cy="320" r="40" fill="#81C784"/>
+  </g>
+  <path d="M256 140 Q256 100 220 110" stroke="#D4903E" stroke-width="20" stroke-linecap="round" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- add baby-themed icon for first debate badge
- show badge images on user and stats pages
- centralize badge image paths

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a88e1bd6fc832d83397a3f1549637b