### PR TITLE
Increase badge size and remove background

### DIFF
--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -110,8 +110,8 @@ export default function MyStats() {
                 {badges.map((badge) => {
                   const image = badgeImages[badge];
                   return (
-                    <Badge key={badge} variant="secondary" style={image ? { padding: '2px' } : {}}>
-                      {image ? <img src={image} alt={badge} style={{ width: '16px', height: '16px' }} /> : badge}
+                    <Badge key={badge} variant="secondary" style={image ? { padding: '4px' } : {}}>
+                      {image ? <img src={image} alt={badge} style={{ width: '24px', height: '24px' }} /> : badge}
                     </Badge>
                   );
                 })}

--- a/pages/user/[username].js
+++ b/pages/user/[username].js
@@ -69,8 +69,8 @@ export default function UserProfile({ user, debates }) {
                   {user.badges.map((badge) => {
                     const image = badgeImages[badge];
                     return (
-                      <Badge key={badge} variant="secondary" style={image ? { padding: '2px' } : {}}>
-                        {image ? <img src={image} alt={badge} style={{ width: '16px', height: '16px' }} /> : badge}
+                      <Badge key={badge} variant="secondary" style={image ? { padding: '4px' } : {}}>
+                        {image ? <img src={image} alt={badge} style={{ width: '24px', height: '24px' }} /> : badge}
                       </Badge>
                     );
                   })}

--- a/public/badges/first-debate.svg
+++ b/public/badges/first-debate.svg
@@ -5,7 +5,6 @@
       <stop offset="100%" stop-color="#000000"/>
     </radialGradient>
   </defs>
-  <rect width="512" height="512" fill="#000000"/>
   <circle cx="256" cy="256" r="220" fill="url(#glow)"/>
   <circle cx="256" cy="256" r="170" fill="#FFE5AD"/>
   <circle cx="206" cy="240" r="30" fill="#333333"/>


### PR DESCRIPTION
## Summary
- enlarge badge images on user profile and stats pages
- remove solid background from badge SVG for transparency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a892e02224832d8b8bcbf76156a148