### PR TITLE
Make debates clickable on profile and stats pages

### DIFF
--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { useSession, signIn } from 'next-auth/react';
 import { Badge } from '../components/ui/badge';
 import badgeImages from '../lib/badgeImages';
@@ -136,29 +137,44 @@ export default function MyStats() {
           </Select>
         </div>
         {debates.map((debate) => (
-          <div key={debate._id} style={{ backgroundColor: 'white', color: '#333', padding: '15px', borderRadius: '8px', marginBottom: '25px' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              <div style={{ alignSelf: 'flex-start', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#FF4D4D', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopLeftRadius: '4px', marginLeft: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
-                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
-                  {debate.instigateText}
-                </p>
+          <Link
+            key={debate._id}
+            href={{ pathname: '/deliberate', query: { id: debate._id } }}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <div
+              style={{
+                backgroundColor: 'white',
+                color: '#333',
+                padding: '15px',
+                borderRadius: '8px',
+                marginBottom: '25px',
+                cursor: 'pointer'
+              }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                <div style={{ alignSelf: 'flex-start', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#FF4D4D', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopLeftRadius: '4px', marginLeft: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
+                  <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
+                    {debate.instigateText}
+                  </p>
+                </div>
+                <div style={{ alignSelf: 'flex-end', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#4D94FF', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopRightRadius: '4px', marginRight: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
+                  <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
+                    {debate.debateText}
+                  </p>
+                </div>
               </div>
-              <div style={{ alignSelf: 'flex-end', maxWidth: isMobile ? '80%' : '60%', backgroundColor: '#4D94FF', color: 'white', padding: '12px 16px', borderRadius: '16px', borderTopRightRadius: '4px', marginRight: 0, boxShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
-                <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
-                  {debate.debateText}
-                </p>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
+                <span style={{ color: '#FF4D4D' }}>Red Votes: {debate.votesRed || 0}</span>
+                <span style={{ color: '#4D94FF' }}>Blue Votes: {debate.votesBlue || 0}</span>
               </div>
+              {debate.userWroteSide && (
+                <div style={{ marginTop: '8px', textAlign: 'center', fontWeight: 'bold' }}>
+                  You wrote: {debate.userWroteSide === 'red' ? 'Red' : 'Blue'}
+                </div>
+              )}
             </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
-              <span style={{ color: '#FF4D4D' }}>Red Votes: {debate.votesRed || 0}</span>
-              <span style={{ color: '#4D94FF' }}>Blue Votes: {debate.votesBlue || 0}</span>
-            </div>
-            {debate.userWroteSide && (
-              <div style={{ marginTop: '8px', textAlign: 'center', fontWeight: 'bold' }}>
-                You wrote: {debate.userWroteSide === 'red' ? 'Red' : 'Blue'}
-              </div>
-            )}
-          </div>
+          </Link>
         ))}
         {debates.length === 0 && (
           <p className="text-base" style={{ textAlign: 'center' }}>You have not participated in any debates yet.</p>

--- a/pages/user/[username].js
+++ b/pages/user/[username].js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import dbConnect from '../../lib/dbConnect';
 import User from '../../models/User';
 import Deliberate from '../../models/Deliberate';
@@ -99,57 +100,63 @@ export default function UserProfile({ user, debates }) {
               </Select>
             </div>
             {displayedDebates.map((d) => (
-              <div
+              <Link
                 key={d._id}
-                style={{
-                  backgroundColor: 'white',
-                  color: '#333',
-                  padding: '15px',
-                  borderRadius: '8px',
-                  marginBottom: '25px'
-                }}
+                href={{ pathname: '/deliberate', query: { id: d._id } }}
+                style={{ textDecoration: 'none', color: 'inherit' }}
               >
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                  <div
-                    style={{
-                      alignSelf: 'flex-start',
-                      maxWidth: isMobile ? '80%' : '60%',
-                      backgroundColor: '#FF4D4D',
-                      color: 'white',
-                      padding: '12px 16px',
-                      borderRadius: '16px',
-                      borderTopLeftRadius: '4px',
-                      marginLeft: 0,
-                      boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
-                    }}
-                  >
-                    <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
-                      {d.instigateText}
-                    </p>
+                <div
+                  style={{
+                    backgroundColor: 'white',
+                    color: '#333',
+                    padding: '15px',
+                    borderRadius: '8px',
+                    marginBottom: '25px',
+                    cursor: 'pointer'
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                    <div
+                      style={{
+                        alignSelf: 'flex-start',
+                        maxWidth: isMobile ? '80%' : '60%',
+                        backgroundColor: '#FF4D4D',
+                        color: 'white',
+                        padding: '12px 16px',
+                        borderRadius: '16px',
+                        borderTopLeftRadius: '4px',
+                        marginLeft: 0,
+                        boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
+                      }}
+                    >
+                      <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
+                        {d.instigateText}
+                      </p>
+                    </div>
+                    <div
+                      style={{
+                        alignSelf: 'flex-end',
+                        maxWidth: isMobile ? '80%' : '60%',
+                        backgroundColor: '#4D94FF',
+                        color: 'white',
+                        padding: '12px 16px',
+                        borderRadius: '16px',
+                        borderTopRightRadius: '4px',
+                        marginRight: 0,
+                        boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
+                      }}
+                    >
+                      <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
+                        {d.debateText}
+                      </p>
+                    </div>
                   </div>
-                  <div
-                    style={{
-                      alignSelf: 'flex-end',
-                      maxWidth: isMobile ? '80%' : '60%',
-                      backgroundColor: '#4D94FF',
-                      color: 'white',
-                      padding: '12px 16px',
-                      borderRadius: '16px',
-                      borderTopRightRadius: '4px',
-                      marginRight: 0,
-                      boxShadow: '0 1px 2px rgba(0,0,0,0.1)'
-                    }}
-                  >
-                    <p className={isMobile ? 'text-base' : 'text-lg'} style={{ margin: 0 }}>
-                      {d.debateText}
-                    </p>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
+                    <span style={{ color: '#FF4D4D' }}>Red Votes: {d.votesRed || 0}</span>
+                    <span style={{ color: '#4D94FF' }}>Blue Votes: {d.votesBlue || 0}</span>
                   </div>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '8px' }}>
-                  <span style={{ color: '#FF4D4D' }}>Red Votes: {d.votesRed || 0}</span>
-                  <span style={{ color: '#4D94FF' }}>Blue Votes: {d.votesBlue || 0}</span>
-                </div>
-              </div>
+              </Link>
             ))}
             <Pagination>
               <PaginationContent>


### PR DESCRIPTION
## Summary
- Make debates on user profile pages clickable by wrapping them in links to the deliberation view
- Enable navigation to debates from the My Stats page with link-wrapped debate cards

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba532d14832db73d02c54b56c88e