### PR TITLE
sync profile color scheme across site

### DIFF
--- a/lib/ColorSchemeContext.js
+++ b/lib/ColorSchemeContext.js
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+export const ColorSchemeContext = createContext({
+  colorScheme: 'light',
+  setColorScheme: () => {},
+});
+
+export function useColorScheme() {
+  return useContext(ColorSchemeContext);
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,28 +1,37 @@
 import '../styles/globals.css';
 import { SessionProvider, useSession } from 'next-auth/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import NavBar from '../components/NavBar';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
 import { Analytics } from "@vercel/analytics/react";
+import { ColorSchemeContext } from '../lib/ColorSchemeContext';
 
 function ThemeProvider({ children }) {
     const { status } = useSession();
+    const [colorScheme, setColorScheme] = useState('light');
+
     useEffect(() => {
-        const applyScheme = scheme => {
-            document.body.classList.remove('light', 'dark', 'blue');
-            document.body.classList.add(scheme || 'light');
-        };
+        document.body.classList.remove('light', 'dark', 'blue');
+        document.body.classList.add(colorScheme || 'light');
+    }, [colorScheme]);
+
+    useEffect(() => {
         if (status === 'authenticated') {
             fetch('/api/profile')
                 .then(res => res.json())
-                .then(data => applyScheme(data.colorScheme))
-                .catch(() => applyScheme('light'));
+                .then(data => setColorScheme(data.colorScheme || 'light'))
+                .catch(() => setColorScheme('light'));
         } else {
-            applyScheme('light');
+            setColorScheme('light');
         }
     }, [status]);
-    return children;
+
+    return (
+        <ColorSchemeContext.Provider value={{ colorScheme, setColorScheme }}>
+            {children}
+        </ColorSchemeContext.Provider>
+    );
 }
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,5 +1,6 @@
 import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
+import { useColorScheme } from '../lib/ColorSchemeContext';
 import { useRouter } from 'next/router';
 
 export default function Profile() {
@@ -7,6 +8,7 @@ export default function Profile() {
   const router = useRouter();
   const [form, setForm] = useState({ profilePicture: '', username: '', bio: '', selectedBadge: '', colorScheme: 'light' });
   const [badges, setBadges] = useState([]);
+  const { setColorScheme } = useColorScheme();
 
   useEffect(() => {
     if (status === 'authenticated') {
@@ -28,6 +30,9 @@ export default function Profile() {
   const handleChange = e => {
     const { name, value } = e.target;
     setForm(prev => ({ ...prev, [name]: value }));
+    if (name === 'colorScheme') {
+      setColorScheme(value);
+    }
   };
 
   const handleFileChange = e => {


### PR DESCRIPTION
## Summary
- add color scheme context for sharing user's site theme
- update app theme provider to apply and expose current color scheme
- apply new color scheme immediately when changed in profile editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Please define the MONGO_URI environment variable in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd4754a0832d92b7afc5ca56d332