### PR TITLE
Position skip and share buttons on mobile

### DIFF
--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -236,7 +236,7 @@ export default function DeliberatePage({ initialDebates }) {
                   style={{
                       position: 'absolute',
                       top: '50%',
-                      left: isMobile ? '50%' : redWidth,
+                      left: isMobile ? '33%' : redWidth,
                       transform: 'translate(-50%, -50%)',
                       padding: '10px 20px',
                       backgroundColor: '#f0f0f0',
@@ -255,7 +255,7 @@ export default function DeliberatePage({ initialDebates }) {
                   style={{
                       position: 'absolute',
                       top: '75%',
-                      left: isMobile ? '50%' : redWidth,
+                      left: isMobile ? '66%' : redWidth,
                       transform: 'translate(-50%, -50%)',
                       padding: '10px 20px',
                       backgroundColor: '#f0f0f0',


### PR DESCRIPTION
## Summary
- Position skip button at one-third of the screen on mobile
- Position share button at two-thirds of the screen on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8f053998c832db02dd5e15b437d79