### PR TITLE
Use PNG images for First Debate and 5 Debates badges

### DIFF
--- a/lib/badgeImages.js
+++ b/lib/badgeImages.js
@@ -1,5 +1,6 @@
 const badgeImages = {
-  'First Debate': '/badges/first-debate.svg'
+  'First Debate': '/badges/firstdebate.png',
+  '5 Debates': '/badges/5debates.png'
 };
 
 export default badgeImages;


### PR DESCRIPTION
## Summary
- display First Debate badge using `firstdebate.png`
- display 5 Debates badge using `5debates.png`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abcd162d24832d9e89fc79d8436a16