### PR TITLE
Limit instigate submissions to 10 per hour

### DIFF
--- a/pages/api/instigate.js
+++ b/pages/api/instigate.js
@@ -22,6 +22,16 @@ export default async function handler(req, res) {
                 .json({ error: 'Text must be under 200 characters.' });
         }
         try {
+            const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+            const recentCount = await Instigate.countDocuments({
+                createdBy: creator,
+                createdAt: { $gte: oneHourAgo },
+            });
+            if (recentCount >= 10) {
+                return res
+                    .status(429)
+                    .json({ error: 'You can only submit 10 instigates per hour.' });
+            }
             const newInstigate = await Instigate.create({ text, createdBy: creator });
             await updateBadges(creator);
             return res.status(201).json(newInstigate);

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -40,11 +40,16 @@ export default function InstigatePage() {
         }
 
         try {
-            await fetch('/api/instigate', {
+            const res = await fetch('/api/instigate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ text: newInstigate.trim() }),
             });
+            if (!res.ok) {
+                const data = await res.json();
+                alert(data.error || 'Failed to submit instigate.');
+                return;
+            }
             setNewInstigate('');
             fetchInstigates();
         } catch (error) {


### PR DESCRIPTION
## Summary
- Enforce a per-user rate limit of 10 instigates per hour on the API
- Surface API errors on the instigate page to inform users about rate limits

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b32d2d1050832d8ef4688e0a960f23