### PR TITLE
Allow admin to update front page banner

### DIFF
--- a/models/Banner.js
+++ b/models/Banner.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const BannerSchema = new mongoose.Schema({
+    imageUrl: {
+        type: String,
+        required: true,
+    },
+});
+
+export default mongoose.models.Banner || mongoose.model('Banner', BannerSchema);

--- a/pages/admin/banner.js
+++ b/pages/admin/banner.js
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../api/auth/[...nextauth]';
+import dbConnect from '../../lib/dbConnect';
+import Banner from '../../models/Banner';
+
+export default function BannerAdmin({ initialUrl }) {
+  const [imageUrl, setImageUrl] = useState(initialUrl || '');
+  const [message, setMessage] = useState('');
+
+  const updateBanner = async () => {
+    const res = await fetch('/api/banner', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ imageUrl }),
+    });
+    if (res.ok) {
+      setMessage('Banner updated');
+    } else {
+      setMessage('Error updating banner');
+    }
+  };
+
+  return (
+    <div style={{ paddingTop: '70px', maxWidth: '800px', margin: '0 auto' }}>
+      <h1 className="heading-1">Front Page Banner</h1>
+      <input
+        type="text"
+        value={imageUrl}
+        onChange={(e) => setImageUrl(e.target.value)}
+        placeholder="Image URL"
+        style={{ width: '100%', marginBottom: '10px' }}
+      />
+      <button onClick={updateBanner}>Update Banner</button>
+      {message && <p>{message}</p>}
+      {imageUrl && (
+        <img src={imageUrl} alt="Banner preview" style={{ width: '100%', marginTop: '20px' }} />
+      )}
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  const admins = (process.env.ADMIN_EMAILS || '').split(',').map(a => a.trim());
+  if (!session || !admins.includes(session.user.email)) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+  await dbConnect();
+  const banner = await Banner.findOne({}).lean();
+  return {
+    props: {
+      initialUrl: banner ? banner.imageUrl : '',
+    },
+  };
+}

--- a/pages/api/banner.js
+++ b/pages/api/banner.js
@@ -1,0 +1,40 @@
+import dbConnect from '../../lib/dbConnect';
+import Banner from '../../models/Banner';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+
+function isAdmin(email) {
+    const admins = (process.env.ADMIN_EMAILS || '').split(',').map(a => a.trim());
+    return email && admins.includes(email);
+}
+
+export default async function handler(req, res) {
+    await dbConnect();
+    const session = await getServerSession(req, res, authOptions);
+
+    if (req.method === 'GET') {
+        const banner = await Banner.findOne({});
+        return res.status(200).json({ imageUrl: banner ? banner.imageUrl : '' });
+    }
+
+    if (req.method === 'POST') {
+        if (!session || !isAdmin(session.user.email)) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+        const { imageUrl } = req.body;
+        if (!imageUrl) {
+            return res.status(400).json({ error: 'Missing imageUrl' });
+        }
+        let banner = await Banner.findOne({});
+        if (banner) {
+            banner.imageUrl = imageUrl;
+            await banner.save();
+        } else {
+            banner = await Banner.create({ imageUrl });
+        }
+        return res.status(200).json({ imageUrl: banner.imageUrl });
+    }
+
+    res.setHeader('Allow', ['GET', 'POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,9 @@
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
+import dbConnect from '../lib/dbConnect';
+import Banner from '../models/Banner';
 
-export default function Home() {
+export default function Home({ bannerUrl }) {
     const router = useRouter();
     const [isMobile, setIsMobile] = useState(false);
 
@@ -20,15 +22,21 @@ export default function Home() {
             style={{
                 display: 'flex',
                 flexDirection: 'column',
-                height: '100vh',
-                overflow: 'hidden',
+                minHeight: '100vh',
             }}
         >
+            {bannerUrl && (
+                <img
+                    src={bannerUrl}
+                    alt="Banner"
+                    style={{ width: '100%', height: 'auto', flexShrink: 0 }}
+                />
+            )}
             {/* Split Screen */}
             <div
                 style={{
                     display: 'flex',
-                    height: '100%',
+                    flex: 1,
                     flexDirection: isMobile ? 'column' : 'row',
                 }}
             >
@@ -98,4 +106,14 @@ export default function Home() {
             </div>
         </div>
     );
+}
+
+export async function getServerSideProps() {
+    await dbConnect();
+    const banner = await Banner.findOne({}).lean();
+    return {
+        props: {
+            bannerUrl: banner ? banner.imageUrl : '',
+        },
+    };
 }


### PR DESCRIPTION
## Summary
- add Banner model and API endpoint to store the home page banner image
- create admin page for updating the banner image URL
- display dynamic banner on home page using stored URL

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf41852dd0832da865d532b31bf4e0