### PR TITLE
Add placeholder sponsors API endpoint

### DIFF
--- a/pages/api/sponsors.js
+++ b/pages/api/sponsors.js
@@ -1,0 +1,9 @@
+export default async function handler(req, res) {
+  try {
+    // Placeholder implementation; replace with real sponsor lookup.
+    res.status(200).json({ sponsors: [] });
+  } catch (error) {
+    console.error('Error fetching sponsors:', error);
+    res.status(500).json({ error: 'Failed to fetch sponsors' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/sponsors` endpoint with graceful error handling

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf46d0b360832d94b105dd557cea99