### PR TITLE
Gracefully handle missing MongoDB connection on homepage

### DIFF
--- a/lib/dbConnect.js
+++ b/lib/dbConnect.js
@@ -1,11 +1,5 @@
 import mongoose from 'mongoose';
 
-const MONGO_URI = process.env.MONGO_URI;
-
-if (!MONGO_URI) {
-    throw new Error('Please define the MONGO_URI environment variable in .env.local');
-}
-
 // Use global scope to maintain a cached connection across hot reloads in development.
 let cached = global.mongoose;
 
@@ -14,6 +8,11 @@ if (!cached) {
 }
 
 async function dbConnect() {
+    const MONGO_URI = process.env.MONGO_URI;
+    if (!MONGO_URI) {
+        throw new Error('Please define the MONGO_URI environment variable in .env.local');
+    }
+
     // If a connection is already established, reuse it.
     if (cached.conn) {
         return cached.conn;

--- a/pages/index.js
+++ b/pages/index.js
@@ -109,11 +109,17 @@ export default function Home({ bannerUrl }) {
 }
 
 export async function getServerSideProps() {
-    await dbConnect();
-    const banner = await Banner.findOne({}).lean();
+    let bannerUrl = '';
+    if (process.env.MONGO_URI) {
+        try {
+            await dbConnect();
+            const banner = await Banner.findOne({}).lean();
+            bannerUrl = banner ? banner.imageUrl : '';
+        } catch (err) {
+            console.error('Failed to load banner:', err);
+        }
+    }
     return {
-        props: {
-            bannerUrl: banner ? banner.imageUrl : '',
-        },
+        props: { bannerUrl },
     };
 }


### PR DESCRIPTION
## Summary
- avoid throwing during db connection setup when `MONGO_URI` is absent
- render homepage without banner when database is unavailable

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1d50dded4832db0b292dc49d68341