### PR TITLE
Hide NavBar on home page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import '../styles/globals.css';
 import { SessionProvider, useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import NavBar from '../components/NavBar';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
@@ -52,11 +53,14 @@ function ThemeProvider({ children }) {
 }
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
+    const router = useRouter();
+    const showNavBar = router.pathname !== '/';
+
     return (
         <SessionProvider session={session}>
             <ThemeProvider>
                 <DefaultSeo {...SEO} />
-                <NavBar />
+                {showNavBar && <NavBar />}
                 <Component {...pageProps} />
                 <Analytics/>
             </ThemeProvider>


### PR DESCRIPTION
## Summary
- Hide NavBar when visiting the landing page so split-screen content is unobstructed.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1d8c8d208832d9169c747655e75a9