### PR TITLE
Restore navbar on home page and fix split-screen layout

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,6 @@
 import '../styles/globals.css';
 import { SessionProvider, useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
 import NavBar from '../components/NavBar';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
@@ -53,14 +52,11 @@ function ThemeProvider({ children }) {
 }
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
-    const router = useRouter();
-    const showNavBar = router.pathname !== '/';
-
     return (
         <SessionProvider session={session}>
             <ThemeProvider>
                 <DefaultSeo {...SEO} />
-                {showNavBar && <NavBar />}
+                <NavBar />
                 <Component {...pageProps} />
                 <Analytics/>
             </ThemeProvider>

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,9 @@ export default function Home({ bannerUrl }) {
             style={{
                 display: 'flex',
                 flexDirection: 'column',
-                minHeight: '100vh',
+                height: '100vh',
+                paddingTop: '74px',
+                boxSizing: 'border-box',
             }}
         >
             {bannerUrl && (


### PR DESCRIPTION
## Summary
- Always render `NavBar` so the home page includes the navigation bar.
- Adjust home page container height and padding so the red/blue split fills the screen beneath the fixed navbar.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc02978c832d82ae74866ee3a939