### PR TITLE
Ensure navbar gradient covers home top padding

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,7 @@ export default function Home({ bannerUrl }) {
                 height: '100vh',
                 paddingTop: '74px',
                 boxSizing: 'border-box',
+                background: 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)',
             }}
         >
             {bannerUrl && (


### PR DESCRIPTION
## Summary
- Continue left/right red-blue gradient behind the navbar on the home page to remove the white strip

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1e46996c4832dbaf0768b9d209416