### PR TITLE
Sync navbar gradient with Deliberate hover

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -121,7 +121,7 @@ export default function NavBar() {
                 justifyContent: 'center',
                 gap: '20px',
                 padding: '10px 0',
-                background: 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)',
+                background: 'var(--nav-gradient, linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%))',
                 position: 'fixed',
                 top: 0,
                 width: '100%',

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -22,6 +22,26 @@ export default function DeliberatePage({ initialDebates }) {
     const [isMobile, setIsMobile] = useState(false);
 
     useEffect(() => {
+        const gradient =
+            hoveringSide === 'red'
+                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
+                : hoveringSide === 'blue'
+                    ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
+                    : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        if (typeof document !== 'undefined') {
+            document.documentElement.style.setProperty('--nav-gradient', gradient);
+        }
+    }, [hoveringSide]);
+
+    useEffect(() => {
+        return () => {
+            if (typeof document !== 'undefined') {
+                document.documentElement.style.removeProperty('--nav-gradient');
+            }
+        };
+    }, []);
+
+    useEffect(() => {
         const handleResize = () => setIsMobile(window.innerWidth <= 768);
         if (typeof window !== 'undefined') {
             handleResize();


### PR DESCRIPTION
## Summary
- expose navbar background via `--nav-gradient` CSS variable
- update Deliberate page to adjust navbar gradient when hovering each side

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed178668832d8f9c1287c67ad141