### PR TITLE
Sync hover gradients with navbar across pages

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -25,6 +25,26 @@ export default function DebatePage({ initialDebates }) {
     }, []);
 
     useEffect(() => {
+        const gradient =
+            hoveringSide === 'red'
+                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
+                : hoveringSide === 'blue'
+                ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
+                : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        if (typeof document !== 'undefined') {
+            document.documentElement.style.setProperty('--nav-gradient', gradient);
+        }
+    }, [hoveringSide]);
+
+    useEffect(() => {
+        return () => {
+            if (typeof document !== 'undefined') {
+                document.documentElement.style.removeProperty('--nav-gradient');
+            }
+        };
+    }, []);
+
+    useEffect(() => {
         const handleClickOutside = (event) => {
             const searchBar = document.querySelector('.search-bar-container');
             if (searchBar && !searchBar.contains(event.target) && !searchTerm) {
@@ -395,9 +415,11 @@ export default function DebatePage({ initialDebates }) {
 
             {/* Right Side (Blue) */}
             <div
+                onMouseEnter={() => setHoveringSide('blue')}
+                onMouseLeave={() => setHoveringSide('')}
                 style={{
                     flex: 1,
-                    backgroundColor: '#4D94FF',
+                    backgroundColor: hoveringSide === 'blue' ? '#76ACFF' : '#4D94FF',
                     padding: '20px',
                     boxSizing: 'border-box',
                     color: 'white',

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,6 +17,26 @@ export default function Home({ bannerUrl }) {
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
+    useEffect(() => {
+        const gradient =
+            hoveredSide === 'left'
+                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
+                : hoveredSide === 'right'
+                ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
+                : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        if (typeof document !== 'undefined') {
+            document.documentElement.style.setProperty('--nav-gradient', gradient);
+        }
+    }, [hoveredSide]);
+
+    useEffect(() => {
+        return () => {
+            if (typeof document !== 'undefined') {
+                document.documentElement.style.removeProperty('--nav-gradient');
+            }
+        };
+    }, []);
+
     // Whether user is signed in or not, we show the main content
     return (
         <div


### PR DESCRIPTION
## Summary
- Update home and debate pages to set `--nav-gradient` so navbar hover colors match body gradients
- Add blue-side hover animation to debate page for consistent left/right behavior

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68c1efe821b0832da871eae196e29701