### PR TITLE
Align NavBar background with page background

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -121,7 +121,7 @@ export default function NavBar() {
                 justifyContent: 'center',
                 gap: '20px',
                 padding: '10px 0',
-                background: 'var(--nav-gradient, linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%))',
+                background: 'var(--nav-gradient, transparent)',
                 position: 'fixed',
                 top: 0,
                 width: '100%',


### PR DESCRIPTION
## Summary
- Make NavBar background transparent by default so it mirrors the page and uses red/blue gradient only when defined

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1f2ef5cd8832daaa299f9e9732f72