### PR TITLE
Align hover transition timing across layout

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -121,6 +121,7 @@ export default function NavBar() {
                 justifyContent: 'center',
                 gap: '20px',
                 padding: '10px 0',
+                transition: 'background 0.3s ease',
                 background: 'var(--nav-gradient, transparent)',
                 position: 'fixed',
                 top: 0,

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,6 +46,7 @@ export default function Home({ bannerUrl }) {
                 height: '100vh',
                 paddingTop: '74px',
                 boxSizing: 'border-box',
+                transition: 'background 0.3s ease',
                 background:
                     hoveredSide === 'left'
                         ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'


### PR DESCRIPTION
## Summary
- Add background transition to navigation bar for smoother hover color shifts
- Transition background of home page container to match navigation timing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1f5ba0370832da319ed09811361c8