### PR TITLE
Synchronize navbar gradient updates with hover interactions

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -1,5 +1,5 @@
 // pages/debate.js
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import { NextSeo } from 'next-seo';
 
 export default function DebatePage({ initialDebates }) {
@@ -8,6 +8,8 @@ export default function DebatePage({ initialDebates }) {
     const [debateText, setDebateText] = useState('');
     const [hoveringSide, setHoveringSide] = useState('');
     const [isMobile, setIsMobile] = useState(false);
+    const useIsomorphicLayoutEffect =
+        typeof window !== 'undefined' ? useLayoutEffect : useEffect;
     // Search-related state
     const [searchTerm, setSearchTerm] = useState('');
     const [searchResults, setSearchResults] = useState([]);
@@ -24,7 +26,7 @@ export default function DebatePage({ initialDebates }) {
         return () => window.removeEventListener('resize', checkMobile);
     }, []);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const gradient =
             hoveringSide === 'red'
                 ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
@@ -36,7 +38,7 @@ export default function DebatePage({ initialDebates }) {
         }
     }, [hoveringSide]);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         return () => {
             if (typeof document !== 'undefined') {
                 document.documentElement.style.removeProperty('--nav-gradient');

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -1,5 +1,5 @@
 // pages/deliberate/index.js
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
@@ -20,8 +20,10 @@ export default function DeliberatePage({ initialDebates }) {
     const [showVotes, setShowVotes] = useState(false);
     const [hoveringSide, setHoveringSide] = useState('');
     const [isMobile, setIsMobile] = useState(false);
+    const useIsomorphicLayoutEffect =
+        typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const gradient =
             hoveringSide === 'red'
                 ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
@@ -33,7 +35,7 @@ export default function DeliberatePage({ initialDebates }) {
         }
     }, [hoveringSide]);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         return () => {
             if (typeof document !== 'undefined') {
                 document.documentElement.style.removeProperty('--nav-gradient');

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import dbConnect from '../lib/dbConnect';
 import Banner from '../models/Banner';
 
@@ -7,6 +7,8 @@ export default function Home({ bannerUrl }) {
     const router = useRouter();
     const [isMobile, setIsMobile] = useState(false);
     const [hoveredSide, setHoveredSide] = useState(null);
+    const useIsomorphicLayoutEffect =
+        typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
     useEffect(() => {
         const handleResize = () => {
@@ -17,7 +19,7 @@ export default function Home({ bannerUrl }) {
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const gradient =
             hoveredSide === 'left'
                 ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
@@ -29,7 +31,7 @@ export default function Home({ bannerUrl }) {
         }
     }, [hoveredSide]);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         return () => {
             if (typeof document !== 'undefined') {
                 document.documentElement.style.removeProperty('--nav-gradient');


### PR DESCRIPTION
## Summary
- use an isomorphic layout effect so the navbar gradient updates immediately with hover changes
- apply the same gradient timing fix on the home, debate, and deliberate pages

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dca7781758832d86edb37882a1e75f