### PR TITLE
Ensure Next.js runs in server mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.next/
 node_modules/

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,12 @@
 const path = require('path');
 
 module.exports = {
+    // Ensure the application runs with the default Node.js server runtime.
+    // The project depends on API routes and getServerSideProps, which are
+    // incompatible with Next.js' static export mode. Explicitly opting into
+    // the standalone output avoids Next trying to statically export the app
+    // when running in development or production.
+    output: 'standalone',
     reactStrictMode: true,
     webpack: (config, { isServer }) => {
         // Example: Add custom aliases


### PR DESCRIPTION
## Summary
- opt into Next.js' standalone output so API routes and server-side props continue to work
- ignore the .next build output directory in Git

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcab788438832da0a17d349e715136