### PR TITLE
Align navigation gradient with debate and deliberate hover states

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -26,17 +26,15 @@ export default function DebatePage({ initialDebates }) {
         return () => window.removeEventListener('resize', checkMobile);
     }, []);
 
+    const leftSideColor = hoveringSide === 'red' ? '#FF6A6A' : '#FF4D4D';
+    const rightSideColor = hoveringSide === 'blue' ? '#76ACFF' : '#4D94FF';
+
     useIsomorphicLayoutEffect(() => {
-        const gradient =
-            hoveringSide === 'red'
-                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
-                : hoveringSide === 'blue'
-                ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
-                : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        const gradient = `linear-gradient(to right, ${leftSideColor} 50%, ${rightSideColor} 50%)`;
         if (typeof document !== 'undefined') {
             document.documentElement.style.setProperty('--nav-gradient', gradient);
         }
-    }, [hoveringSide]);
+    }, [leftSideColor, rightSideColor]);
 
     useIsomorphicLayoutEffect(() => {
         return () => {
@@ -322,7 +320,7 @@ export default function DebatePage({ initialDebates }) {
                 onMouseLeave={() => setHoveringSide('')}
                 style={{
                     flex: 1,
-                    backgroundColor: hoveringSide === 'red' ? '#FF6A6A' : '#FF4D4D',
+                    backgroundColor: leftSideColor,
                     padding: '20px',
                     boxSizing: 'border-box',
                     color: 'white',
@@ -421,7 +419,7 @@ export default function DebatePage({ initialDebates }) {
                 onMouseLeave={() => setHoveringSide('')}
                 style={{
                     flex: 1,
-                    backgroundColor: hoveringSide === 'blue' ? '#76ACFF' : '#4D94FF',
+                    backgroundColor: rightSideColor,
                     padding: '20px',
                     boxSizing: 'border-box',
                     color: 'white',

--- a/pages/deliberate.js
+++ b/pages/deliberate.js
@@ -23,17 +23,15 @@ export default function DeliberatePage({ initialDebates }) {
     const useIsomorphicLayoutEffect =
         typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
+    const leftSideColor = hoveringSide === 'red' ? '#FF6A6A' : '#FF4D4D';
+    const rightSideColor = hoveringSide === 'blue' ? '#76ACFF' : '#4D94FF';
+
     useIsomorphicLayoutEffect(() => {
-        const gradient =
-            hoveringSide === 'red'
-                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
-                : hoveringSide === 'blue'
-                    ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
-                    : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        const gradient = `linear-gradient(to right, ${leftSideColor} 50%, ${rightSideColor} 50%)`;
         if (typeof document !== 'undefined') {
             document.documentElement.style.setProperty('--nav-gradient', gradient);
         }
-    }, [hoveringSide]);
+    }, [leftSideColor, rightSideColor]);
 
     useIsomorphicLayoutEffect(() => {
         return () => {
@@ -315,7 +313,7 @@ export default function DeliberatePage({ initialDebates }) {
                     style={{
                         width: isMobile ? '100%' : redSize,
                         height: isMobile ? redSize : '100%',
-                        backgroundColor: hoveringSide === 'red' ? '#FF6A6A' : '#FF4D4D',
+                        backgroundColor: leftSideColor,
                         color: 'white',
                         display: 'flex',
                         flexDirection: 'column',
@@ -379,7 +377,7 @@ export default function DeliberatePage({ initialDebates }) {
                     style={{
                         width: isMobile ? '100%' : blueSize,
                         height: isMobile ? blueSize : '100%',
-                        backgroundColor: hoveringSide === 'blue' ? '#76ACFF' : '#4D94FF',
+                        backgroundColor: rightSideColor,
                         color: 'white',
                         display: 'flex',
                         flexDirection: 'column',

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,17 +19,15 @@ export default function Home({ bannerUrl }) {
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
+    const leftSideColor = hoveredSide === 'left' ? '#FF6A6A' : '#FF4D4D';
+    const rightSideColor = hoveredSide === 'right' ? '#76ACFF' : '#4D94FF';
+
     useIsomorphicLayoutEffect(() => {
-        const gradient =
-            hoveredSide === 'left'
-                ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
-                : hoveredSide === 'right'
-                ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
-                : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)';
+        const gradient = `linear-gradient(to right, ${leftSideColor} 50%, ${rightSideColor} 50%)`;
         if (typeof document !== 'undefined') {
             document.documentElement.style.setProperty('--nav-gradient', gradient);
         }
-    }, [hoveredSide]);
+    }, [leftSideColor, rightSideColor]);
 
     useIsomorphicLayoutEffect(() => {
         return () => {
@@ -49,12 +47,7 @@ export default function Home({ bannerUrl }) {
                 paddingTop: '74px',
                 boxSizing: 'border-box',
                 transition: 'background 0.3s ease',
-                background:
-                    hoveredSide === 'left'
-                        ? 'linear-gradient(to right, #FF6A6A 50%, #4D94FF 50%)'
-                        : hoveredSide === 'right'
-                        ? 'linear-gradient(to right, #FF4D4D 50%, #76ACFF 50%)'
-                        : 'linear-gradient(to right, #FF4D4D 50%, #4D94FF 50%)',
+                background: `linear-gradient(to right, ${leftSideColor} 50%, ${rightSideColor} 50%)`,
             }}
         >
             {bannerUrl && (
@@ -77,8 +70,7 @@ export default function Home({ bannerUrl }) {
                     onClick={() => router.push('/instigate')}
                     style={{
                         flex: 1,
-                        backgroundColor:
-                            hoveredSide === 'left' ? '#FF6A6A' : '#FF4D4D',
+                        backgroundColor: leftSideColor,
                         color: 'white',
                         display: 'flex',
                         justifyContent: 'center',
@@ -110,8 +102,7 @@ export default function Home({ bannerUrl }) {
                     onClick={() => router.push('/debate')}
                     style={{
                         flex: 1,
-                        backgroundColor:
-                            hoveredSide === 'right' ? '#76ACFF' : '#4D94FF',
+                        backgroundColor: rightSideColor,
                         color: 'white',
                         display: 'flex',
                         justifyContent: 'center',


### PR DESCRIPTION
## Summary
- compute shared left and right side colors on debate, deliberate, and home pages
- update navigation gradient to follow the active hover colors so the bar matches the panels

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcaf3dc0d8832d8a1c4684ffa9241e