### PR TITLE
Make navigation and page borders white

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -84,7 +84,7 @@ export default function NavBar() {
         padding: '10px 20px',
         fontSize: '16px',
         fontWeight: 'bold',
-        border: '2px solid var(--nav-button-border, rgba(31, 31, 31, 0.4))',
+        border: '2px solid var(--nav-button-border, rgba(255, 255, 255, 0.6))',
         borderRadius: '999px',
         backgroundColor: 'transparent',
         color: '#ffffff',
@@ -98,23 +98,23 @@ export default function NavBar() {
     // Hover effects
     const handleMouseEnter = (e) => {
         e.target.style.transform = 'translateY(2px) scale(0.98)';
-        e.target.style.borderColor = 'var(--nav-button-border-hover, rgba(31, 31, 31, 0.6))';
+        e.target.style.borderColor = 'var(--nav-button-border-hover, rgba(255, 255, 255, 0.85))';
         e.target.style.color = '#ffffff';
     };
     const handleMouseLeave = (e) => {
         e.target.style.transform = 'translateY(0)';
-        e.target.style.borderColor = 'var(--nav-button-border, rgba(31, 31, 31, 0.4))';
+        e.target.style.borderColor = 'var(--nav-button-border, rgba(255, 255, 255, 0.6))';
         e.target.style.color = '#ffffff';
     };
 
     const handleCircularMouseEnter = (e) => {
         e.target.style.transform = 'translateY(2px) scale(0.98)';
-        e.target.style.borderColor = 'var(--nav-button-border-hover, rgba(31, 31, 31, 0.6))';
+        e.target.style.borderColor = 'var(--nav-button-border-hover, rgba(255, 255, 255, 0.85))';
         e.target.style.color = '#ffffff';
     };
     const handleCircularMouseLeave = (e) => {
         e.target.style.transform = 'translateY(0)';
-        e.target.style.borderColor = 'var(--nav-button-border, rgba(31, 31, 31, 0.4))';
+        e.target.style.borderColor = 'var(--nav-button-border, rgba(255, 255, 255, 0.6))';
         e.target.style.color = '#ffffff';
     };
 
@@ -149,7 +149,7 @@ export default function NavBar() {
                         height: isMobile ? '54px' : '44px',
                         borderRadius: '50%',
                         backgroundColor: 'transparent',
-                        border: '2px solid var(--nav-button-border, rgba(31, 31, 31, 0.4))',
+                        border: '2px solid var(--nav-button-border, rgba(255, 255, 255, 0.6))',
                         color: '#ffffff'
                     }}
                     onMouseEnter={handleCircularMouseEnter}

--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -96,8 +96,10 @@ export default function InstigatePage() {
                             padding: '10px',
                             fontSize: '36px',
                             borderRadius: '4px',
-                            border: '1px solid #ccc',
+                            border: '1px solid rgba(255, 255, 255, 0.8)',
                             resize: 'none',
+                            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                            color: '#ffffff',
                         }}
                     />
                     <div
@@ -106,7 +108,7 @@ export default function InstigatePage() {
                             bottom: '15px',
                             right: '15px',
                             fontSize: '14px',
-                            color: '#555',
+                            color: '#ffffff',
                             pointerEvents: 'none',
                         }}
                     >

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -173,7 +173,15 @@ export default function Leaderboard() {
           </div>
         )}
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <Select value={sort} onValueChange={setSort}>
+          <Select
+            value={sort}
+            onValueChange={setSort}
+            style={{
+              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              color: '#ffffff',
+              border: '1px solid rgba(255, 255, 255, 0.7)',
+            }}
+          >
             <SelectTrigger className="w-[180px]">
               <SelectValue placeholder="Sort by" />
             </SelectTrigger>

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -123,7 +123,15 @@ export default function MyStats() {
           </div>
         </div>
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>
-          <Select value={sort} onValueChange={setSort}>
+          <Select
+            value={sort}
+            onValueChange={setSort}
+            style={{
+              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              color: '#ffffff',
+              border: '1px solid rgba(255, 255, 255, 0.7)',
+            }}
+          >
             <SelectTrigger className="w-[180px]">
               <SelectValue placeholder="Sort by" />
             </SelectTrigger>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -56,12 +56,25 @@ export default function Profile() {
   if (status === 'loading') return <p>Loading...</p>;
   if (status === 'unauthenticated') return <p>Please sign in to edit your profile.</p>;
 
+  const inputStyle = {
+    padding: '10px',
+    borderRadius: '8px',
+    border: '1px solid rgba(255, 255, 255, 0.7)',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    color: '#ffffff',
+  };
+
+  const labelStyle = {
+    color: '#ffffff',
+    fontWeight: '600',
+  };
+
   return (
-    <div style={{ padding: '20px', maxWidth: '600px', margin: '80px auto' }}>
+    <div style={{ padding: '20px', maxWidth: '600px', margin: '80px auto', color: '#ffffff' }}>
       <h1>Edit Profile</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        <label>Profile Picture</label>
-        <input type="file" accept="image/*" onChange={handleFileChange} />
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+        <label style={labelStyle}>Profile Picture</label>
+        <input type="file" accept="image/*" onChange={handleFileChange} style={inputStyle} />
         {form.profilePicture && (
           <img
             src={form.profilePicture}
@@ -69,24 +82,38 @@ export default function Profile() {
             style={{ width: '100px', height: '100px', objectFit: 'cover' }}
           />
         )}
-        <label>Username</label>
-        <input name="username" value={form.username} onChange={handleChange} />
-        <label>Bio</label>
-        <textarea name="bio" value={form.bio} onChange={handleChange} />
-        <label>Public Badge</label>
-        <select name="selectedBadge" value={form.selectedBadge} onChange={handleChange}>
+        <label style={labelStyle}>Username</label>
+        <input name="username" value={form.username} onChange={handleChange} style={inputStyle} />
+        <label style={labelStyle}>Bio</label>
+        <textarea name="bio" value={form.bio} onChange={handleChange} style={{ ...inputStyle, minHeight: '120px' }} />
+        <label style={labelStyle}>Public Badge</label>
+        <select name="selectedBadge" value={form.selectedBadge} onChange={handleChange} style={inputStyle}>
           <option value="">None</option>
           {badges.map(b => (
             <option key={b} value={b}>{b}</option>
           ))}
         </select>
-        <label>Color Scheme</label>
-        <select name="colorScheme" value={form.colorScheme} onChange={handleChange}>
+        <label style={labelStyle}>Color Scheme</label>
+        <select name="colorScheme" value={form.colorScheme} onChange={handleChange} style={inputStyle}>
           <option value="light">Light</option>
           <option value="dark">Dark</option>
           <option value="blue">Blue</option>
         </select>
-        <button type="submit" style={{ marginTop: '10px' }}>Save</button>
+        <button
+          type="submit"
+          style={{
+            marginTop: '10px',
+            padding: '10px 16px',
+            borderRadius: '999px',
+            border: '1px solid rgba(255, 255, 255, 0.7)',
+            backgroundColor: 'transparent',
+            color: '#ffffff',
+            fontWeight: '600',
+            cursor: 'pointer',
+          }}
+        >
+          Save
+        </button>
       </form>
     </div>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,10 +12,10 @@
     --line-height-h2: 1.3;
     --font-size-h3: 1.5rem;
     --line-height-h3: 1.4;
-    --nav-button-color: #1f1f1f;
-    --nav-button-color-hover: #000000;
-    --nav-button-border: rgba(31, 31, 31, 0.4);
-    --nav-button-border-hover: rgba(31, 31, 31, 0.6);
+    --nav-button-color: #ffffff;
+    --nav-button-color-hover: #f5f5f5;
+    --nav-button-border: rgba(255, 255, 255, 0.6);
+    --nav-button-border-hover: rgba(255, 255, 255, 0.85);
 }
 
 body {
@@ -87,7 +87,7 @@ body.blue {
     position: absolute;
     right: 20px;
     background-color: transparent;
-    border: 2px solid var(--nav-button-border, rgba(31, 31, 31, 0.4));
+    border: 2px solid var(--nav-button-border, rgba(255, 255, 255, 0.6));
     cursor: pointer;
     backdrop-filter: blur(4px);
     transition: transform 0.15s ease, border-color 0.15s ease;
@@ -95,12 +95,12 @@ body.blue {
 
 .hamburger-button:hover,
 .hamburger-button.open {
-    border-color: var(--nav-button-border-hover, rgba(31, 31, 31, 0.6));
+    border-color: var(--nav-button-border-hover, rgba(255, 255, 255, 0.85));
     transform: scale(0.96);
 }
 
 .hamburger-button span {
-    background: var(--nav-button-color, #1f1f1f);
+    background: var(--nav-button-color, #ffffff);
     border-radius: 10px;
     height: 3px;
     margin: 3px 0;


### PR DESCRIPTION
## Summary
- switch navbar button variables and handlers to white borders for consistent contrast
- refresh profile, stats, and leaderboard inputs/selects with white-outlined styling
- update instigate textarea styling to use white borders and text accents

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd57c84024832d8db814d9cba5f063