### PR TITLE
Restore white background for instigate textarea

### DIFF
--- a/pages/instigate.js
+++ b/pages/instigate.js
@@ -96,10 +96,10 @@ export default function InstigatePage() {
                             padding: '10px',
                             fontSize: '36px',
                             borderRadius: '4px',
-                            border: '1px solid rgba(255, 255, 255, 0.8)',
+                            border: '1px solid rgba(0, 0, 0, 0.2)',
                             resize: 'none',
-                            backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                            color: '#ffffff',
+                            backgroundColor: '#ffffff',
+                            color: '#000000',
                         }}
                     />
                     <div


### PR DESCRIPTION
## Summary
- restore the white background in the instigate submission textarea
- adjust the border and text color to match the restored styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd59ce72bc832db59ebe82e81d80a3