### PR TITLE
Fix dropdown contrast on stats pages

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -177,8 +177,8 @@ export default function Leaderboard() {
             value={sort}
             onValueChange={setSort}
             style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.1)',
-              color: '#ffffff',
+              backgroundColor: 'rgba(255, 255, 255, 0.95)',
+              color: '#1f2937',
               border: '1px solid rgba(255, 255, 255, 0.7)',
             }}
           >

--- a/pages/my-stats.js
+++ b/pages/my-stats.js
@@ -127,8 +127,8 @@ export default function MyStats() {
             value={sort}
             onValueChange={setSort}
             style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.1)',
-              color: '#ffffff',
+              backgroundColor: 'rgba(255, 255, 255, 0.95)',
+              color: '#1f2937',
               border: '1px solid rgba(255, 255, 255, 0.7)',
             }}
           >


### PR DESCRIPTION
## Summary
- increase the dropdown background opacity on the My Stats and Leaderboard pages
- switch the dropdown text color to a dark tone for better readability

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd763349a0832db59bddd8e19ea084