### PR TITLE
Align debate search suggestions dropdown

### DIFF
--- a/pages/debate.js
+++ b/pages/debate.js
@@ -249,6 +249,7 @@ export default function DebatePage({ initialDebates }) {
     const searchResultsList =
         showSearchResults && searchResults.length > 0 ? (
             <div
+                className="search-results-dropdown"
                 style={{
                     position: 'absolute',
                     top: '100%',
@@ -263,6 +264,7 @@ export default function DebatePage({ initialDebates }) {
                     boxShadow:
                         '0 16px 24px rgba(15, 23, 42, 0.08), 0 8px 16px rgba(15, 23, 42, 0.04)',
                     zIndex: 1000,
+                    boxSizing: 'border-box',
                 }}
             >
                 {searchResults.map((instigate, index) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -160,6 +160,15 @@ body.blue {
     font-weight: 500;
 }
 
+.search-results-dropdown {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+.search-results-dropdown::-webkit-scrollbar {
+    display: none;
+}
+
 .pagination-link.disabled {
     opacity: 0.5;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- align the debate search suggestions dropdown with the search bar by matching box sizing
- hide the scrollbar for the suggestions list while keeping scrolling support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df4b0ff29c832da03f7000480f2714