### PR TITLE
Improve Deliberate voting animation on iOS

### DIFF
--- a/ios/BickerApp.xcodeproj/project.pbxproj
+++ b/ios/BickerApp.xcodeproj/project.pbxproj
@@ -30,8 +30,9 @@
                 4D9FFE2531594E22B2CE4768 /* LeaderboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9FFE2431594E22B2CE4768 /* LeaderboardView.swift */; };
 		E731D94D6E12493993F7C539 /* MyStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E731D94C6E12493993F7C539 /* MyStatsView.swift */; };
 		5D228AECD40D43A9AA8184AD /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D228AEBD40D43A9AA8184AD /* NotificationsView.swift */; };
-		25B2F4D48DC748BC93BFB3AF /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */; };
+                25B2F4D48DC748BC93BFB3AF /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */; };
+                A1B2C3D4E5F6A7B8C9D0E1F2 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */; };
+                B9E8F4C7D1A64E4C9FA6B5C2 /* ProportionalSplitLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E8F4C6D1A64E4C9FA6B5C2 /* ProportionalSplitLayout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,10 +59,11 @@
                 31837E94ADE648389682A4B6 /* DeliberateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliberateView.swift; sourceTree = "<group>"; };
                 C4F8B2B1E5AB4F92B6C77E8C /* DeliberateVoteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliberateVoteStore.swift; sourceTree = "<group>"; };
                 4D9FFE2431594E22B2CE4768 /* LeaderboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardView.swift; sourceTree = "<group>"; };
-		E731D94C6E12493993F7C539 /* MyStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStatsView.swift; sourceTree = "<group>"; };
-		5D228AEBD40D43A9AA8184AD /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
-		25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+                E731D94C6E12493993F7C539 /* MyStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStatsView.swift; sourceTree = "<group>"; };
+                5D228AEBD40D43A9AA8184AD /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+                25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+                A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+                B9E8F4C6D1A64E4C9FA6B5C2 /* ProportionalSplitLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalSplitLayout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,22 +126,31 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
-		3BFE5F4ADF6549EA8B4F4AB6 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				E44B59F65D7B48C78051E5B7 /* ContentView.swift */,
-				9614ED6E7B794AD58F7B3740 /* InstigateView.swift */,
-				01006EDBD755417AB786A0B3 /* DebateView.swift */,
-				31837E94ADE648389682A4B6 /* DeliberateView.swift */,
-				4D9FFE2431594E22B2CE4768 /* LeaderboardView.swift */,
-				E731D94C6E12493993F7C539 /* MyStatsView.swift */,
-				5D228AEBD40D43A9AA8184AD /* NotificationsView.swift */,
-				25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */,
-				A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
+                3BFE5F4ADF6549EA8B4F4AB6 /* Views */ = {
+                        isa = PBXGroup;
+                        children = (
+                                E44B59F65D7B48C78051E5B7 /* ContentView.swift */,
+                                9614ED6E7B794AD58F7B3740 /* InstigateView.swift */,
+                                01006EDBD755417AB786A0B3 /* DebateView.swift */,
+                                31837E94ADE648389682A4B6 /* DeliberateView.swift */,
+                                4D9FFE2431594E22B2CE4768 /* LeaderboardView.swift */,
+                                E731D94C6E12493993F7C539 /* MyStatsView.swift */,
+                                5D228AEBD40D43A9AA8184AD /* NotificationsView.swift */,
+                                25B2F4D38DC748BC93BFB3AF /* ProfileView.swift */,
+                                A1B2C3D4E5F6A7B8C9D0E1F3 /* UserProfileView.swift */,
+                                B9E8F4C5D1A64E4C9FA6B5C2 /* Support */,
+                        );
+                        path = Views;
+                        sourceTree = "<group>";
+                };
+                B9E8F4C5D1A64E4C9FA6B5C2 /* Support */ = {
+                        isa = PBXGroup;
+                        children = (
+                                B9E8F4C6D1A64E4C9FA6B5C2 /* ProportionalSplitLayout.swift */,
+                        );
+                        path = Support;
+                        sourceTree = "<group>";
+                };
 		6C8C215B58624E4D97FEA00F /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -242,9 +253,10 @@
                                 4D9FFE2531594E22B2CE4768 /* LeaderboardView.swift in Sources */,
                                 E731D94D6E12493993F7C539 /* MyStatsView.swift in Sources */,
                                 5D228AECD40D43A9AA8184AD /* NotificationsView.swift in Sources */,
-				25B2F4D48DC748BC93BFB3AF /* ProfileView.swift in Sources */,
-				A1B2C3D4E5F6A7B8C9D0E1F2 /* UserProfileView.swift in Sources */,
-			);
+                                25B2F4D48DC748BC93BFB3AF /* ProfileView.swift in Sources */,
+                                A1B2C3D4E5F6A7B8C9D0E1F2 /* UserProfileView.swift in Sources */,
+                                B9E8F4C7D1A64E4C9FA6B5C2 /* ProportionalSplitLayout.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/ios/BickerApp/Views/DeliberateView.swift
+++ b/ios/BickerApp/Views/DeliberateView.swift
@@ -157,253 +157,51 @@ struct DeliberateCardView: View {
             let clampedRedFill = max(0.0, min(1.0, redFill))
             let clampedBlueFill = max(0.0, min(1.0, blueFill))
 
-            if isCompact {
-                // Mobile: Stack vertically
-                VStack(spacing: 0) {
-                    // Top Side: Red - Instigate
-                    Button {
+            ProportionalSplitLayout(
+                axis: isCompact ? .vertical : .horizontal,
+                leadingFraction: clampedRedFill,
+                trailingFraction: clampedBlueFill
+            ) {
+                voteButton(
+                    color: Color(red: 1.0, green: 0.3, blue: 0.3),
+                    title: deliberate.instigateText ?? "",
+                    profile: deliberate.instigator,
+                    reactions: deliberate.reactions?.red,
+                    votes: deliberate.votesRed ?? 0,
+                    percent: redPercent,
+                    fontSize: isCompact ? 24 : 36,
+                    voteCountFontSize: isCompact ? 20 : 28,
+                    percentFontSize: isCompact ? 16 : 20,
+                    showVotes: showVotes,
+                    showVoteDetails: showVoteDetails,
+                    isInteractionDisabled: viewModel.isVoting || hasVoted,
+                    action: {
                         guard !hasVoted, !viewModel.isVoting else { return }
-                        Task {
-                            await viewModel.vote(side: "red", index: index)
-                        }
-                    } label: {
-                        ZStack {
-                            Color(red: 1.0, green: 0.3, blue: 0.3)
-                                .ignoresSafeArea()
-                            
-                            VStack(spacing: 20) {
-                                Text(deliberate.instigateText ?? "")
-                                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                                    .foregroundColor(.white)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, 20)
-                                
-                                ProfilePreview(
-                                    user: deliberate.instigator,
-                                    textColor: .white.opacity(0.9)
-                                ) { username in
-                                    viewModel.selectedUsername = UsernameWrapper(value: username)
-                                }
-                                
-                                // Reactions
-                                if let reactions = deliberate.reactions, let redReactions = reactions.red, !redReactions.isEmpty {
-                                    VStack(spacing: 8) {
-                                        ForEach(Array(redReactions.keys.sorted()), id: \.self) { emoji in
-                                            Text("\(emoji) \(redReactions[emoji] ?? 0)")
-                                                .font(.system(.caption, design: .rounded))
-                                                .foregroundColor(.white.opacity(0.9))
-                                        }
-                                    }
-                                }
-                                
-                                if showVotes {
-                                    VStack(spacing: 4) {
-                                        Text("Votes: \(deliberate.votesRed ?? 0)")
-                                            .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                            .foregroundColor(.white)
-                                        Text("\(Int(redPercent * 100))%")
-                                            .font(.system(size: 16, weight: .medium, design: .rounded))
-                                            .foregroundColor(.white.opacity(0.9))
-                                    }
-                                    .opacity(showVoteDetails ? 1 : 0)
-                                    .scaleEffect(showVoteDetails ? 1 : 0.96)
-                                    .animation(.easeOut(duration: 0.35), value: showVoteDetails)
-                                }
-
-                                Spacer()
-                            }
-                            .padding(.top, 60)
-                        }
+                        Task { await viewModel.vote(side: "red", index: index) }
                     }
-                    .buttonStyle(VibrantButtonStyle(isDisabled: viewModel.isVoting || hasVoted))
-                    .disabled(viewModel.isVoting)
-                    .frame(height: geometry.size.height * clampedRedFill)
-                    .animation(VoteRevealTiming.fillAnimation, value: redFill)
-                    
-                    // Bottom Side: Blue - Debate
-                    Button {
+                )
+
+                voteButton(
+                    color: Color(red: 0.3, green: 0.58, blue: 1.0),
+                    title: deliberate.debateText ?? "",
+                    profile: deliberate.creator,
+                    reactions: deliberate.reactions?.blue,
+                    votes: deliberate.votesBlue ?? 0,
+                    percent: bluePercent,
+                    fontSize: isCompact ? 24 : 36,
+                    voteCountFontSize: isCompact ? 20 : 28,
+                    percentFontSize: isCompact ? 16 : 20,
+                    showVotes: showVotes,
+                    showVoteDetails: showVoteDetails,
+                    isInteractionDisabled: viewModel.isVoting || hasVoted,
+                    action: {
                         guard !hasVoted, !viewModel.isVoting else { return }
-                        Task {
-                            await viewModel.vote(side: "blue", index: index)
-                        }
-                    } label: {
-                        ZStack {
-                            Color(red: 0.3, green: 0.58, blue: 1.0)
-                                .ignoresSafeArea()
-                            
-                            VStack(spacing: 20) {
-                                Text(deliberate.debateText ?? "")
-                                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                                    .foregroundColor(.white)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, 20)
-                                
-                                ProfilePreview(
-                                    user: deliberate.creator,
-                                    textColor: .white.opacity(0.9)
-                                ) { username in
-                                    viewModel.selectedUsername = UsernameWrapper(value: username)
-                                }
-                                
-                                // Reactions
-                                if let reactions = deliberate.reactions, let blueReactions = reactions.blue, !blueReactions.isEmpty {
-                                    VStack(spacing: 8) {
-                                        ForEach(Array(blueReactions.keys.sorted()), id: \.self) { emoji in
-                                            Text("\(emoji) \(blueReactions[emoji] ?? 0)")
-                                                .font(.system(.caption, design: .rounded))
-                                                .foregroundColor(.white.opacity(0.9))
-                                        }
-                                    }
-                                }
-                                
-                                if showVotes {
-                                    VStack(spacing: 4) {
-                                        Text("Votes: \(deliberate.votesBlue ?? 0)")
-                                            .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                            .foregroundColor(.white)
-                                        Text("\(Int(bluePercent * 100))%")
-                                            .font(.system(size: 16, weight: .medium, design: .rounded))
-                                            .foregroundColor(.white.opacity(0.9))
-                                    }
-                                    .opacity(showVoteDetails ? 1 : 0)
-                                    .scaleEffect(showVoteDetails ? 1 : 0.96)
-                                    .animation(.easeOut(duration: 0.35), value: showVoteDetails)
-                                }
-
-                                Spacer()
-                            }
-                            .padding(.top, 60)
-                        }
+                        Task { await viewModel.vote(side: "blue", index: index) }
                     }
-                    .buttonStyle(VibrantButtonStyle(isDisabled: viewModel.isVoting || hasVoted))
-                    .disabled(viewModel.isVoting)
-                    .frame(height: geometry.size.height * clampedBlueFill)
-                    .animation(VoteRevealTiming.fillAnimation, value: blueFill)
-                }
-            } else {
-                // Desktop: Side by side
-                HStack(spacing: 0) {
-                    // Left Side: Red - Instigate
-                    Button {
-                        guard !hasVoted, !viewModel.isVoting else { return }
-                        Task {
-                            await viewModel.vote(side: "red", index: index)
-                        }
-                    } label: {
-                        ZStack {
-                            Color(red: 1.0, green: 0.3, blue: 0.3)
-                                .ignoresSafeArea()
-                            
-                            VStack(spacing: 20) {
-                                Text(deliberate.instigateText ?? "")
-                                    .font(.system(size: 36, weight: .bold, design: .rounded))
-                                    .foregroundColor(.white)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, 20)
-                                
-                                ProfilePreview(
-                                    user: deliberate.instigator,
-                                    textColor: .white.opacity(0.9)
-                                ) { username in
-                                    viewModel.selectedUsername = UsernameWrapper(value: username)
-                                }
-                                
-                                // Reactions
-                                if let reactions = deliberate.reactions, let redReactions = reactions.red, !redReactions.isEmpty {
-                                    VStack(spacing: 8) {
-                                        ForEach(Array(redReactions.keys.sorted()), id: \.self) { emoji in
-                                            Text("\(emoji) \(redReactions[emoji] ?? 0)")
-                                                .font(.system(.caption, design: .rounded))
-                                                .foregroundColor(.white.opacity(0.9))
-                                        }
-                                    }
-                                }
-                                
-                                if showVotes {
-                                    VStack(spacing: 4) {
-                                        Text("Votes: \(deliberate.votesRed ?? 0)")
-                                            .font(.system(size: 28, weight: .semibold, design: .rounded))
-                                            .foregroundColor(.white)
-                                        Text("\(Int(redPercent * 100))%")
-                                            .font(.system(size: 20, weight: .medium, design: .rounded))
-                                            .foregroundColor(.white.opacity(0.9))
-                                    }
-                                    .opacity(showVoteDetails ? 1 : 0)
-                                    .scaleEffect(showVoteDetails ? 1 : 0.96)
-                                    .animation(.easeOut(duration: 0.35), value: showVoteDetails)
-                                }
-
-                                Spacer()
-                            }
-                            .padding(.top, 60)
-                        }
-                    }
-                    .buttonStyle(VibrantButtonStyle(isDisabled: viewModel.isVoting || hasVoted))
-                    .disabled(viewModel.isVoting)
-                    .frame(width: geometry.size.width * clampedRedFill)
-                    .animation(VoteRevealTiming.fillAnimation, value: redFill)
-
-                    // Right Side: Blue - Debate
-                    Button {
-                        guard !hasVoted, !viewModel.isVoting else { return }
-                        Task {
-                            await viewModel.vote(side: "blue", index: index)
-                        }
-                    } label: {
-                        ZStack {
-                            Color(red: 0.3, green: 0.58, blue: 1.0)
-                                .ignoresSafeArea()
-                            
-                            VStack(spacing: 20) {
-                                Text(deliberate.debateText ?? "")
-                                    .font(.system(size: 36, weight: .bold, design: .rounded))
-                                    .foregroundColor(.white)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, 20)
-                                
-                                ProfilePreview(
-                                    user: deliberate.creator,
-                                    textColor: .white.opacity(0.9)
-                                ) { username in
-                                    viewModel.selectedUsername = UsernameWrapper(value: username)
-                                }
-                                
-                                // Reactions
-                                if let reactions = deliberate.reactions, let blueReactions = reactions.blue, !blueReactions.isEmpty {
-                                    VStack(spacing: 8) {
-                                        ForEach(Array(blueReactions.keys.sorted()), id: \.self) { emoji in
-                                            Text("\(emoji) \(blueReactions[emoji] ?? 0)")
-                                                .font(.system(.caption, design: .rounded))
-                                                .foregroundColor(.white.opacity(0.9))
-                                        }
-                                    }
-                                }
-                                
-                                if showVotes {
-                                    VStack(spacing: 4) {
-                                        Text("Votes: \(deliberate.votesBlue ?? 0)")
-                                            .font(.system(size: 28, weight: .semibold, design: .rounded))
-                                            .foregroundColor(.white)
-                                        Text("\(Int(bluePercent * 100))%")
-                                            .font(.system(size: 20, weight: .medium, design: .rounded))
-                                            .foregroundColor(.white.opacity(0.9))
-                                    }
-                                    .opacity(showVoteDetails ? 1 : 0)
-                                    .scaleEffect(showVoteDetails ? 1 : 0.96)
-                                    .animation(.easeOut(duration: 0.35), value: showVoteDetails)
-                                }
-
-                                Spacer()
-                            }
-                            .padding(.top, 60)
-                        }
-                    }
-                    .buttonStyle(VibrantButtonStyle(isDisabled: viewModel.isVoting || hasVoted))
-                    .disabled(viewModel.isVoting)
-                    .frame(width: geometry.size.width * clampedBlueFill)
-                    .animation(VoteRevealTiming.fillAnimation, value: blueFill)
-                }
+                )
             }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .ignoresSafeArea()
         }
         .onAppear {
             hasAnimatedReveal = false
@@ -503,6 +301,81 @@ struct DeliberateCardView: View {
             showVoteDetails = false
         }
         hasAnimatedReveal = false
+    }
+
+    @ViewBuilder
+    private func voteButton(
+        color: Color,
+        title: String,
+        profile: Deliberate.Creator?,
+        reactions: [String: Int]?,
+        votes: Int,
+        percent: Double,
+        fontSize: CGFloat,
+        voteCountFontSize: CGFloat,
+        percentFontSize: CGFloat,
+        showVotes: Bool,
+        showVoteDetails: Bool,
+        isInteractionDisabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            ZStack {
+                color
+
+                VStack(spacing: 20) {
+                    Text(title)
+                        .font(.system(size: fontSize, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+
+                    ProfilePreview(
+                        user: profile,
+                        textColor: .white.opacity(0.9)
+                    ) { username in
+                        viewModel.selectedUsername = UsernameWrapper(value: username)
+                    }
+
+                    if let reactions, !reactions.isEmpty {
+                        VStack(spacing: 8) {
+                            ForEach(Array(reactions.keys.sorted()), id: \.self) { emoji in
+                                Text("\(emoji) \(reactions[emoji] ?? 0)")
+                                    .font(.system(.caption, design: .rounded))
+                                    .foregroundColor(.white.opacity(0.9))
+                            }
+                        }
+                    }
+
+                    if showVotes {
+                        VStack(spacing: 4) {
+                            Text("Votes: \(votes)")
+                                .font(.system(size: voteCountFontSize, weight: .semibold, design: .rounded))
+                                .foregroundColor(.white)
+                            Text("\(Int(percent * 100))%")
+                                .font(.system(size: percentFontSize, weight: .medium, design: .rounded))
+                                .foregroundColor(.white.opacity(0.9))
+                        }
+                        .opacity(showVoteDetails ? 1 : 0)
+                        .scaleEffect(showVoteDetails ? 1 : 0.96)
+                        .animation(.easeOut(duration: 0.35), value: showVoteDetails)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.top, 60)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(VibrantButtonStyle(isDisabled: isInteractionDisabled))
+        .disabled(isInteractionDisabled)
+        .transaction { transaction in
+            if transaction.animation == nil {
+                transaction.animation = VoteRevealTiming.fillAnimation
+            }
+        }
     }
 }
 

--- a/ios/BickerApp/Views/Support/ProportionalSplitLayout.swift
+++ b/ios/BickerApp/Views/Support/ProportionalSplitLayout.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// A custom layout that animates two child views proportionally along a chosen axis.
+/// The layout guarantees that each child keeps enough space to fit its intrinsic content size
+/// while distributing any extra space using animatable fractions. This avoids the repeated
+/// layout thrashing that can occur when animating frames directly in SwiftUI.
+struct ProportionalSplitLayout: Layout {
+    enum Axis {
+        case vertical
+        case horizontal
+    }
+
+    struct Cache {
+        var size: CGSize = .zero
+        var leadingExtent: CGFloat = 0
+        var trailingExtent: CGFloat = 0
+    }
+
+    var axis: Axis
+    var leadingFraction: CGFloat
+    var trailingFraction: CGFloat
+
+    init(axis: Axis, leadingFraction: CGFloat, trailingFraction: CGFloat) {
+        self.axis = axis
+        self.leadingFraction = leadingFraction
+        self.trailingFraction = trailingFraction
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(leadingFraction, trailingFraction) }
+        set {
+            leadingFraction = newValue.first
+            trailingFraction = newValue.second
+        }
+    }
+
+    func makeCache(subviews: Subviews) -> Cache {
+        Cache()
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache) -> CGSize {
+        let measurement = measure(proposal: proposal, subviews: subviews)
+        cache = measurement
+        return measurement.size
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) {
+        let measurement: Cache
+        if cache.size == .zero {
+            measurement = measure(proposal: proposal, subviews: subviews)
+            cache = measurement
+        } else {
+            measurement = cache
+        }
+
+        guard subviews.count == 2 else { return }
+
+        switch axis {
+        case .vertical:
+            let widthProposal = ProposedViewSize(width: bounds.width, height: measurement.leadingExtent)
+            subviews[0].place(
+                at: CGPoint(x: bounds.minX, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: widthProposal
+            )
+
+            let bottomProposal = ProposedViewSize(width: bounds.width, height: measurement.trailingExtent)
+            subviews[1].place(
+                at: CGPoint(x: bounds.minX, y: bounds.minY + measurement.leadingExtent),
+                anchor: .topLeading,
+                proposal: bottomProposal
+            )
+
+        case .horizontal:
+            let heightProposal = ProposedViewSize(width: measurement.leadingExtent, height: bounds.height)
+            subviews[0].place(
+                at: CGPoint(x: bounds.minX, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: heightProposal
+            )
+
+            let trailingProposal = ProposedViewSize(width: measurement.trailingExtent, height: bounds.height)
+            subviews[1].place(
+                at: CGPoint(x: bounds.minX + measurement.leadingExtent, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: trailingProposal
+            )
+        }
+    }
+
+    private func measure(proposal: ProposedViewSize, subviews: Subviews) -> Cache {
+        guard subviews.count == 2 else { return Cache() }
+
+        let clampedLeading = max(0, min(1, leadingFraction))
+        let clampedTrailing = max(0, min(1, trailingFraction))
+        let totalWeight = max(clampedLeading + clampedTrailing, .leastNonzeroMagnitude)
+
+        switch axis {
+        case .vertical:
+            let intrinsicSizes = subviews.map { $0.sizeThatFits(.unspecified) }
+            let maxWidth = intrinsicSizes.map(\.width).max() ?? 0
+            let proposedWidth = proposal.width ?? maxWidth
+            let finalWidth = max(maxWidth, proposedWidth)
+
+            let minimumHeights = intrinsicSizes.map(\.height)
+            let minimumTotal = minimumHeights.reduce(0, +)
+            let proposedHeight = proposal.height ?? minimumTotal
+            let targetHeight = max(proposedHeight, minimumTotal)
+
+            let extra = max(0, targetHeight - minimumTotal)
+            let leadingExtra = extra * (clampedLeading / totalWeight)
+            let trailingExtra = extra * (clampedTrailing / totalWeight)
+
+            let leadingExtent = minimumHeights[0] + leadingExtra
+            let trailingExtent = minimumHeights[1] + trailingExtra
+            let totalHeight = leadingExtent + trailingExtent
+
+            return Cache(
+                size: CGSize(width: finalWidth, height: totalHeight),
+                leadingExtent: leadingExtent,
+                trailingExtent: trailingExtent
+            )
+
+        case .horizontal:
+            let intrinsicSizes = subviews.map { $0.sizeThatFits(.unspecified) }
+            let maxHeight = intrinsicSizes.map(\.height).max() ?? 0
+            let proposedHeight = proposal.height ?? maxHeight
+            let finalHeight = max(maxHeight, proposedHeight)
+
+            let minimumWidths = intrinsicSizes.map(\.width)
+            let minimumTotal = minimumWidths.reduce(0, +)
+            let proposedWidth = proposal.width ?? minimumTotal
+            let targetWidth = max(proposedWidth, minimumTotal)
+
+            let extra = max(0, targetWidth - minimumTotal)
+            let leadingExtra = extra * (clampedLeading / totalWeight)
+            let trailingExtra = extra * (clampedTrailing / totalWeight)
+
+            let leadingExtent = minimumWidths[0] + leadingExtra
+            let trailingExtent = minimumWidths[1] + trailingExtra
+            let totalWidth = leadingExtent + trailingExtent
+
+            return Cache(
+                size: CGSize(width: totalWidth, height: finalHeight),
+                leadingExtent: leadingExtent,
+                trailingExtent: trailingExtent
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom ProportionalSplitLayout to animate split view proportions without layout thrashing
- refactor DeliberateView vote buttons to use the new layout and shared builder for smoother reveals
- update the Xcode project to include the support file

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154dd068b0832d8f1ba806ca1dfcd6)